### PR TITLE
Add Additional Lifecycle Methods

### DIFF
--- a/Sources/Spezi/Module/Capabilities/Lifecycle/LifecycleHandler.swift
+++ b/Sources/Spezi/Module/Capabilities/Lifecycle/LifecycleHandler.swift
@@ -26,6 +26,30 @@ public protocol LifecycleHandler {
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     )
     
+    /// Replicates  the `applicationDidBecomeActive(_: UIApplication)` functionality of the `UIApplicationDelegate`.
+    ///
+    /// Tells the delegate that the app has become active.
+    /// - Parameter application: Your singleton app object.
+    func applicationDidBecomeActive(_ application: UIApplication)
+    
+    /// Replicates  the `applicationWillResignActive(_: UIApplication)` functionality of the `UIApplicationDelegate`.
+    ///
+    /// Tells the delegate that the app is about to become inactive.
+    /// - Parameter application: Your singleton app object.
+    func applicationWillResignActive(_ application: UIApplication)
+    
+    /// Replicates  the `applicationDidEnterBackground(_: UIApplication)` functionality of the `UIApplicationDelegate`.
+    ///
+    /// Tells the delegate that the app is now in the background.
+    /// - Parameter application: Your singleton app object.
+    func applicationDidEnterBackground(_ application: UIApplication)
+    
+    /// Replicates  the `applicationWillEnterForeground(_: UIApplication)` functionality of the `UIApplicationDelegate`.
+    ///
+    /// Tells the delegate that the app is about to enter the foreground.
+    /// - Parameter application: Your singleton app object.
+    func applicationWillEnterForeground(_ application: UIApplication)
+    
     /// Replicates  the `applicationWillTerminate(_: UIApplication)` functionality of the `UIApplicationDelegate`.
     ///
     /// Tells the delegate when the app is about to terminate.
@@ -46,6 +70,30 @@ extension LifecycleHandler {
     
     // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
+    public func applicationDidBecomeActive(
+        _ application: UIApplication
+    ) { }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func applicationWillResignActive(
+        _ application: UIApplication
+    ) { }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func applicationDidEnterBackground(
+        _ application: UIApplication
+    ) { }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func applicationWillEnterForeground(
+        _ application: UIApplication
+    ) { }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
     public func applicationWillTerminate(
         _ application: UIApplication
     ) { }
@@ -59,6 +107,38 @@ extension Array: LifecycleHandler where Element == LifecycleHandler {
     ) {
         for lifecycleHandler in self {
             lifecycleHandler.willFinishLaunchingWithOptions(application, launchOptions: launchOptions)
+        }
+    }
+    
+    public func applicationDidBecomeActive(
+        _ application: UIApplication
+    ) {
+        for lifecycleHandler in self {
+            lifecycleHandler.applicationDidBecomeActive(application)
+        }
+    }
+    
+    public func applicationWillResignActive(
+        _ application: UIApplication
+    ) {
+        for lifecycleHandler in self {
+            lifecycleHandler.applicationWillResignActive(application)
+        }
+    }
+    
+    public func applicationDidEnterBackground(
+        _ application: UIApplication
+    ) {
+        for lifecycleHandler in self {
+            lifecycleHandler.applicationDidEnterBackground(application)
+        }
+    }
+    
+    public func applicationWillEnterForeground(
+        _ application: UIApplication
+    ) {
+        for lifecycleHandler in self {
+            lifecycleHandler.applicationWillEnterForeground(application)
         }
     }
     

--- a/Sources/Spezi/Module/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
+++ b/Sources/Spezi/Module/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
@@ -25,7 +25,33 @@ extension AnySpezi {
         lifecycleHandler.willFinishLaunchingWithOptions(application, launchOptions: launchOptions)
     }
     
-    func applicationWillTerminate(_ application: UIApplication) {
+    func applicationDidBecomeActive(
+        _ application: UIApplication
+    ) {
+        lifecycleHandler.applicationDidBecomeActive(application)
+    }
+    
+    func applicationWillResignActive(
+        _ application: UIApplication
+    ) {
+        lifecycleHandler.applicationWillResignActive(application)
+    }
+    
+    func applicationDidEnterBackground(
+        _ application: UIApplication
+    ) {
+        lifecycleHandler.applicationDidEnterBackground(application)
+    }
+    
+    func applicationWillEnterForeground(
+        _ application: UIApplication
+    ) {
+        lifecycleHandler.applicationWillEnterForeground(application)
+    }
+    
+    func applicationWillTerminate(
+        _ application: UIApplication
+    ) {
         lifecycleHandler.applicationWillTerminate(application)
     }
 }

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -101,6 +101,22 @@ open class SpeziAppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
     
+    open func applicationDidBecomeActive(_ application: UIApplication) {
+        spezi.applicationDidBecomeActive(application)
+    }
+    
+    open func applicationWillResignActive(_ application: UIApplication) {
+        spezi.applicationWillResignActive(application)
+    }
+    
+    open func applicationDidEnterBackground(_ application: UIApplication) {
+        spezi.applicationDidEnterBackground(application)
+    }
+    
+    open func applicationWillEnterForeground(_ application: UIApplication) {
+        spezi.applicationWillEnterForeground(application)
+    }
+    
     open func applicationWillTerminate(_ application: UIApplication) {
         spezi.applicationWillTerminate(application)
     }

--- a/Tests/SpeziTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
@@ -11,16 +11,33 @@ import XCTest
 import XCTRuntimeAssertions
 
 
+// We disable long identifier names as we want the expectations to be fully expressive.
+// swiftlint:disable identifier_name
 private final class TestLifecycleHandler: Component, LifecycleHandler, TypedCollectionKey {
     typealias ComponentStandard = MockStandard
     
     
     let expectationWillFinishLaunchingWithOption: XCTestExpectation
+    let expectationApplicationDidBecomeActive: XCTestExpectation
+    let expectationApplicationWillResignActive: XCTestExpectation
+    let expectationApplicationDidEnterBackground: XCTestExpectation
+    let expectationApplicationWillEnterForeground: XCTestExpectation
     let expectationApplicationWillTerminate: XCTestExpectation
     
     
-    init(expectationWillFinishLaunchingWithOption: XCTestExpectation, expectationApplicationWillTerminate: XCTestExpectation) {
+    init(
+        expectationWillFinishLaunchingWithOption: XCTestExpectation,
+        expectationApplicationDidBecomeActive: XCTestExpectation,
+        expectationApplicationWillResignActive: XCTestExpectation,
+        expectationApplicationDidEnterBackground: XCTestExpectation,
+        expectationApplicationWillEnterForeground: XCTestExpectation,
+        expectationApplicationWillTerminate: XCTestExpectation
+    ) {
         self.expectationWillFinishLaunchingWithOption = expectationWillFinishLaunchingWithOption
+        self.expectationApplicationDidBecomeActive = expectationApplicationDidBecomeActive
+        self.expectationApplicationWillResignActive = expectationApplicationWillResignActive
+        self.expectationApplicationDidEnterBackground = expectationApplicationDidEnterBackground
+        self.expectationApplicationWillEnterForeground = expectationApplicationWillEnterForeground
         self.expectationApplicationWillTerminate = expectationApplicationWillTerminate
     }
     
@@ -30,6 +47,22 @@ private final class TestLifecycleHandler: Component, LifecycleHandler, TypedColl
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     ) {
         expectationWillFinishLaunchingWithOption.fulfill()
+    }
+    
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        expectationApplicationDidBecomeActive.fulfill()
+    }
+    
+    func applicationWillResignActive(_ application: UIApplication) {
+        expectationApplicationWillResignActive.fulfill()
+    }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        expectationApplicationDidEnterBackground.fulfill()
+    }
+    
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        expectationApplicationWillEnterForeground.fulfill()
     }
     
     func applicationWillTerminate(_ application: UIApplication) {
@@ -44,6 +77,10 @@ private final class EmpfyLifecycleHandler: Component, LifecycleHandler, TypedCol
 
 private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
     let expectationWillFinishLaunchingWithOption: XCTestExpectation
+    let expectationApplicationDidBecomeActive: XCTestExpectation
+    let expectationApplicationWillResignActive: XCTestExpectation
+    let expectationApplicationDidEnterBackground: XCTestExpectation
+    let expectationApplicationWillEnterForeground: XCTestExpectation
     let expectationApplicationWillTerminate: XCTestExpectation
     
     
@@ -51,6 +88,10 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
         Configuration(standard: MockStandard()) {
             TestLifecycleHandler(
                 expectationWillFinishLaunchingWithOption: expectationWillFinishLaunchingWithOption,
+                expectationApplicationDidBecomeActive: expectationApplicationDidBecomeActive,
+                expectationApplicationWillResignActive: expectationApplicationWillResignActive,
+                expectationApplicationDidEnterBackground: expectationApplicationDidEnterBackground,
+                expectationApplicationWillEnterForeground: expectationApplicationWillEnterForeground,
                 expectationApplicationWillTerminate: expectationApplicationWillTerminate
             )
             EmpfyLifecycleHandler()
@@ -58,8 +99,19 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
     }
     
     
-    init(expectationWillFinishLaunchingWithOption: XCTestExpectation, expectationApplicationWillTerminate: XCTestExpectation) {
+    init(
+        expectationWillFinishLaunchingWithOption: XCTestExpectation,
+        expectationApplicationDidBecomeActive: XCTestExpectation,
+        expectationApplicationWillResignActive: XCTestExpectation,
+        expectationApplicationDidEnterBackground: XCTestExpectation,
+        expectationApplicationWillEnterForeground: XCTestExpectation,
+        expectationApplicationWillTerminate: XCTestExpectation
+    ) {
         self.expectationWillFinishLaunchingWithOption = expectationWillFinishLaunchingWithOption
+        self.expectationApplicationDidBecomeActive = expectationApplicationDidBecomeActive
+        self.expectationApplicationWillResignActive = expectationApplicationWillResignActive
+        self.expectationApplicationDidEnterBackground = expectationApplicationDidEnterBackground
+        self.expectationApplicationWillEnterForeground = expectationApplicationWillEnterForeground
         self.expectationApplicationWillTerminate = expectationApplicationWillTerminate
     }
 }
@@ -68,9 +120,18 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
 final class LifecycleTests: XCTestCase {
     func testUIApplicationLifecycleMethods() async throws {
         let expectationWillFinishLaunchingWithOption = XCTestExpectation(description: "WillFinishLaunchingWithOptions")
+        let expectationApplicationDidBecomeActive = XCTestExpectation(description: "ApplicationDidBecomeActive")
+        let expectationApplicationWillResignActive = XCTestExpectation(description: "ApplicationWillResignActive")
+        let expectationApplicationDidEnterBackground = XCTestExpectation(description: "ApplicationDidEnterBackground")
+        let expectationApplicationWillEnterForeground = XCTestExpectation(description: "ApplicationWillEnterForeground")
         let expectationApplicationWillTerminate = XCTestExpectation(description: "ApplicationWillTerminate")
+        
         let testApplicationDelegate = await TestLifecycleHandlerApplicationDelegate(
             expectationWillFinishLaunchingWithOption: expectationWillFinishLaunchingWithOption,
+            expectationApplicationDidBecomeActive: expectationApplicationDidBecomeActive,
+            expectationApplicationWillResignActive: expectationApplicationWillResignActive,
+            expectationApplicationDidEnterBackground: expectationApplicationDidEnterBackground,
+            expectationApplicationWillEnterForeground: expectationApplicationWillEnterForeground,
             expectationApplicationWillTerminate: expectationApplicationWillTerminate
         )
         
@@ -79,11 +140,21 @@ final class LifecycleTests: XCTestCase {
             willFinishLaunchingWithOptions: [UIApplication.LaunchOptionsKey.url: XCTUnwrap(URL(string: "spezi.stanford.edu"))]
         )
         XCTAssertTrue(willFinishLaunchingWithOptions)
-        
         wait(for: [expectationWillFinishLaunchingWithOption])
         
-        await testApplicationDelegate.applicationWillTerminate(UIApplication.shared)
+        await testApplicationDelegate.applicationDidBecomeActive(UIApplication.shared)
+        wait(for: [expectationApplicationDidBecomeActive])
         
+        await testApplicationDelegate.applicationWillResignActive(UIApplication.shared)
+        wait(for: [expectationApplicationWillResignActive])
+        
+        await testApplicationDelegate.applicationDidEnterBackground(UIApplication.shared)
+        wait(for: [expectationApplicationDidEnterBackground])
+        
+        await testApplicationDelegate.applicationWillEnterForeground(UIApplication.shared)
+        wait(for: [expectationApplicationWillEnterForeground])
+        
+        await testApplicationDelegate.applicationWillTerminate(UIApplication.shared)
         wait(for: [expectationApplicationWillTerminate])
     }
 }


### PR DESCRIPTION
# Add Additional Lifecycle Methods

## :recycle: Current situation & Problem
- The current `LifecycleHandler` does not support a wider variety of lifecycle methods for components as listed here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate

## :bulb: Proposed solution
- Extends the `LifecycleHandler` infrastructure to support additional lifecycle handlers including:
  - `func applicationDidBecomeActive(_ application: UIApplication)`
  - `func applicationWillResignActive(_ application: UIApplication)`
  - `func applicationDidEnterBackground(_ application: UIApplication)`
  - `func applicationWillEnterForeground(_ application: UIApplication)`

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
