### PR TITLE
Update LifecycleHandler to Use Scene Methods

### DIFF
--- a/Sources/Spezi/Module/Capabilities/Lifecycle/LifecycleHandler.swift
+++ b/Sources/Spezi/Module/Capabilities/Lifecycle/LifecycleHandler.swift
@@ -26,29 +26,45 @@ public protocol LifecycleHandler {
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     )
     
-    /// Replicates  the `applicationDidBecomeActive(_: UIApplication)` functionality of the `UIApplicationDelegate`.
+    /// Replicates  the `sceneWillEnterForeground(_: UIScene)` functionality of the `UISceneDelegate`.
     ///
-    /// Tells the delegate that the app has become active.
-    /// - Parameter application: Your singleton app object.
+    /// Tells the delegate that the scene is about to begin running in the foreground and become visible to the user.
+    /// - Parameter scene: The scene that is about to enter the foreground.
+    func sceneWillEnterForeground(_ scene: UIScene)
+    
+    /// Replicates  the `sceneDidBecomeActive(_: UIScene)` functionality of the `UISceneDelegate`.
+    ///
+    /// Tells the delegate that the scene became active and is now responding to user events.
+    /// - Parameter scene: The scene that became active and is now responding to user events.
+    func sceneDidBecomeActive(_ scene: UIScene)
+    
+    /// Replicates  the `sceneWillResignActive(_: UIScene)` functionality of the `UISceneDelegate`.
+    ///
+    /// Tells the delegate that the scene is about to resign the active state and stop responding to user events.
+    /// - Parameter scene: The scene that is about to stop responding to user events.
+    func sceneWillResignActive(_ scene: UIScene)
+    
+    /// Replicates  the `sceneDidEnterBackground(_: UIScene)` functionality of the `UISceneDelegate`.
+    ///
+    /// Tells the delegate that the scene is running in the background and is no longer onscreen.
+    /// - Parameter scene: The scene that entered the background.
+    func sceneDidEnterBackground(_ scene: UIScene)
+    
+    /// Depricated, use ``sceneWillEnterForeground(_:)-1k9os`` instead.
+    @available(*, deprecated, renamed: "sceneWillEnterForeground")
+    func applicationWillEnterForeground(_ application: UIApplication)
+    
+    /// Depricated, use ``sceneDidBecomeActive(_:)-6jf8j`` instead.
+    @available(*, deprecated, renamed: "sceneDidBecomeActive")
     func applicationDidBecomeActive(_ application: UIApplication)
     
-    /// Replicates  the `applicationWillResignActive(_: UIApplication)` functionality of the `UIApplicationDelegate`.
-    ///
-    /// Tells the delegate that the app is about to become inactive.
-    /// - Parameter application: Your singleton app object.
+    /// Depricated, use ``sceneWillResignActive(_:)-8e0ee`` instead.
+    @available(*, deprecated, renamed: "sceneWillResignActive")
     func applicationWillResignActive(_ application: UIApplication)
     
-    /// Replicates  the `applicationDidEnterBackground(_: UIApplication)` functionality of the `UIApplicationDelegate`.
-    ///
-    /// Tells the delegate that the app is now in the background.
-    /// - Parameter application: Your singleton app object.
+    /// Depricated, use ``sceneDidEnterBackground(_:)-3t146`` instead.
+    @available(*, deprecated, renamed: "sceneDidEnterBackground")
     func applicationDidEnterBackground(_ application: UIApplication)
-    
-    /// Replicates  the `applicationWillEnterForeground(_: UIApplication)` functionality of the `UIApplicationDelegate`.
-    ///
-    /// Tells the delegate that the app is about to enter the foreground.
-    /// - Parameter application: Your singleton app object.
-    func applicationWillEnterForeground(_ application: UIApplication)
     
     /// Replicates  the `applicationWillTerminate(_: UIApplication)` functionality of the `UIApplicationDelegate`.
     ///
@@ -67,6 +83,30 @@ extension LifecycleHandler {
         _ application: UIApplication,
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     ) { }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func sceneWillEnterForeground(_ scene: UIScene) {
+        applicationWillEnterForeground(UIApplication.shared)
+    }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func sceneDidBecomeActive(_ scene: UIScene) {
+        applicationDidBecomeActive(UIApplication.shared)
+    }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func sceneWillResignActive(_ scene: UIScene) {
+        applicationWillResignActive(UIApplication.shared)
+    }
+    
+    // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
+    // swiftlint:disable:next missing_docs
+    public func sceneDidEnterBackground(_ scene: UIScene) {
+        applicationDidEnterBackground(UIApplication.shared)
+    }
     
     // A documentation for this methodd exists in the `LifecycleHandler` type which SwiftLint doesn't recognize.
     // swiftlint:disable:next missing_docs
@@ -110,35 +150,27 @@ extension Array: LifecycleHandler where Element == LifecycleHandler {
         }
     }
     
-    public func applicationDidBecomeActive(
-        _ application: UIApplication
-    ) {
+    public func sceneWillEnterForeground(_ scene: UIScene) {
         for lifecycleHandler in self {
-            lifecycleHandler.applicationDidBecomeActive(application)
+            lifecycleHandler.sceneWillEnterForeground(scene)
         }
     }
     
-    public func applicationWillResignActive(
-        _ application: UIApplication
-    ) {
+    public func sceneDidBecomeActive(_ scene: UIScene) {
         for lifecycleHandler in self {
-            lifecycleHandler.applicationWillResignActive(application)
+            lifecycleHandler.sceneDidBecomeActive(scene)
         }
     }
     
-    public func applicationDidEnterBackground(
-        _ application: UIApplication
-    ) {
+    public func sceneWillResignActive(_ scene: UIScene) {
         for lifecycleHandler in self {
-            lifecycleHandler.applicationDidEnterBackground(application)
+            lifecycleHandler.sceneWillResignActive(scene)
         }
     }
     
-    public func applicationWillEnterForeground(
-        _ application: UIApplication
-    ) {
+    public func sceneDidEnterBackground(_ scene: UIScene) {
         for lifecycleHandler in self {
-            lifecycleHandler.applicationWillEnterForeground(application)
+            lifecycleHandler.sceneDidEnterBackground(scene)
         }
     }
     

--- a/Sources/Spezi/Module/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
+++ b/Sources/Spezi/Module/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
@@ -25,33 +25,23 @@ extension AnySpezi {
         lifecycleHandler.willFinishLaunchingWithOptions(application, launchOptions: launchOptions)
     }
     
-    func applicationDidBecomeActive(
-        _ application: UIApplication
-    ) {
-        lifecycleHandler.applicationDidBecomeActive(application)
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        lifecycleHandler.sceneWillEnterForeground(scene)
     }
     
-    func applicationWillResignActive(
-        _ application: UIApplication
-    ) {
-        lifecycleHandler.applicationWillResignActive(application)
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        lifecycleHandler.sceneDidBecomeActive(scene)
     }
     
-    func applicationDidEnterBackground(
-        _ application: UIApplication
-    ) {
-        lifecycleHandler.applicationDidEnterBackground(application)
+    func sceneWillResignActive(_ scene: UIScene) {
+        lifecycleHandler.sceneWillResignActive(scene)
     }
     
-    func applicationWillEnterForeground(
-        _ application: UIApplication
-    ) {
-        lifecycleHandler.applicationWillEnterForeground(application)
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        lifecycleHandler.sceneDidEnterBackground(scene)
     }
     
-    func applicationWillTerminate(
-        _ application: UIApplication
-    ) {
+    func applicationWillTerminate(_ application: UIApplication) {
         lifecycleHandler.applicationWillTerminate(application)
     }
 }

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -50,7 +50,7 @@ import SwiftUI
 ///
 /// The ``Component`` documentation provides more information about the structure of components.
 /// Refer to the ``Configuration`` documentation to learn more about the Spezi configuration.
-open class SpeziAppDelegate: NSObject, UIApplicationDelegate {
+open class SpeziAppDelegate: NSObject, UIApplicationDelegate, UISceneDelegate {
     private actor DefaultStandard: Standard {
         typealias BaseType = StandardType
         typealias RemovalContext = BaseType
@@ -101,20 +101,30 @@ open class SpeziAppDelegate: NSObject, UIApplicationDelegate {
         return true
     }
     
-    open func applicationDidBecomeActive(_ application: UIApplication) {
-        spezi.applicationDidBecomeActive(application)
+    open func application(
+        _ application: UIApplication,
+        configurationForConnecting connectingSceneSession: UISceneSession,
+        options: UIScene.ConnectionOptions
+    ) -> UISceneConfiguration {
+        let sceneConfig = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        sceneConfig.delegateClass = Self.self
+        return sceneConfig
     }
     
-    open func applicationWillResignActive(_ application: UIApplication) {
-        spezi.applicationWillResignActive(application)
+    open func sceneWillEnterForeground(_ scene: UIScene) {
+        spezi.sceneWillEnterForeground(scene)
     }
     
-    open func applicationDidEnterBackground(_ application: UIApplication) {
-        spezi.applicationDidEnterBackground(application)
+    open func sceneDidBecomeActive(_ scene: UIScene) {
+        spezi.sceneDidBecomeActive(scene)
     }
     
-    open func applicationWillEnterForeground(_ application: UIApplication) {
-        spezi.applicationWillEnterForeground(application)
+    open func sceneWillResignActive(_ scene: UIScene) {
+        spezi.sceneWillResignActive(scene)
+    }
+    
+    open func sceneDidEnterBackground(_ scene: UIScene) {
+        spezi.sceneDidEnterBackground(scene)
     }
     
     open func applicationWillTerminate(_ application: UIApplication) {

--- a/Tests/SpeziTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/LifecycleTests/LifecycleTests.swift
@@ -11,33 +11,19 @@ import XCTest
 import XCTRuntimeAssertions
 
 
-// We disable long identifier names as we want the expectations to be fully expressive.
-// swiftlint:disable identifier_name
 private final class TestLifecycleHandler: Component, LifecycleHandler, TypedCollectionKey {
     typealias ComponentStandard = MockStandard
     
     
     let expectationWillFinishLaunchingWithOption: XCTestExpectation
-    let expectationApplicationDidBecomeActive: XCTestExpectation
-    let expectationApplicationWillResignActive: XCTestExpectation
-    let expectationApplicationDidEnterBackground: XCTestExpectation
-    let expectationApplicationWillEnterForeground: XCTestExpectation
     let expectationApplicationWillTerminate: XCTestExpectation
     
     
     init(
         expectationWillFinishLaunchingWithOption: XCTestExpectation,
-        expectationApplicationDidBecomeActive: XCTestExpectation,
-        expectationApplicationWillResignActive: XCTestExpectation,
-        expectationApplicationDidEnterBackground: XCTestExpectation,
-        expectationApplicationWillEnterForeground: XCTestExpectation,
         expectationApplicationWillTerminate: XCTestExpectation
     ) {
         self.expectationWillFinishLaunchingWithOption = expectationWillFinishLaunchingWithOption
-        self.expectationApplicationDidBecomeActive = expectationApplicationDidBecomeActive
-        self.expectationApplicationWillResignActive = expectationApplicationWillResignActive
-        self.expectationApplicationDidEnterBackground = expectationApplicationDidEnterBackground
-        self.expectationApplicationWillEnterForeground = expectationApplicationWillEnterForeground
         self.expectationApplicationWillTerminate = expectationApplicationWillTerminate
     }
     
@@ -47,22 +33,6 @@ private final class TestLifecycleHandler: Component, LifecycleHandler, TypedColl
         launchOptions: [UIApplication.LaunchOptionsKey: Any]
     ) {
         expectationWillFinishLaunchingWithOption.fulfill()
-    }
-    
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        expectationApplicationDidBecomeActive.fulfill()
-    }
-    
-    func applicationWillResignActive(_ application: UIApplication) {
-        expectationApplicationWillResignActive.fulfill()
-    }
-    
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        expectationApplicationDidEnterBackground.fulfill()
-    }
-    
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        expectationApplicationWillEnterForeground.fulfill()
     }
     
     func applicationWillTerminate(_ application: UIApplication) {
@@ -77,10 +47,6 @@ private final class EmpfyLifecycleHandler: Component, LifecycleHandler, TypedCol
 
 private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
     let expectationWillFinishLaunchingWithOption: XCTestExpectation
-    let expectationApplicationDidBecomeActive: XCTestExpectation
-    let expectationApplicationWillResignActive: XCTestExpectation
-    let expectationApplicationDidEnterBackground: XCTestExpectation
-    let expectationApplicationWillEnterForeground: XCTestExpectation
     let expectationApplicationWillTerminate: XCTestExpectation
     
     
@@ -88,10 +54,6 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
         Configuration(standard: MockStandard()) {
             TestLifecycleHandler(
                 expectationWillFinishLaunchingWithOption: expectationWillFinishLaunchingWithOption,
-                expectationApplicationDidBecomeActive: expectationApplicationDidBecomeActive,
-                expectationApplicationWillResignActive: expectationApplicationWillResignActive,
-                expectationApplicationDidEnterBackground: expectationApplicationDidEnterBackground,
-                expectationApplicationWillEnterForeground: expectationApplicationWillEnterForeground,
                 expectationApplicationWillTerminate: expectationApplicationWillTerminate
             )
             EmpfyLifecycleHandler()
@@ -101,60 +63,33 @@ private class TestLifecycleHandlerApplicationDelegate: SpeziAppDelegate {
     
     init(
         expectationWillFinishLaunchingWithOption: XCTestExpectation,
-        expectationApplicationDidBecomeActive: XCTestExpectation,
-        expectationApplicationWillResignActive: XCTestExpectation,
-        expectationApplicationDidEnterBackground: XCTestExpectation,
-        expectationApplicationWillEnterForeground: XCTestExpectation,
         expectationApplicationWillTerminate: XCTestExpectation
     ) {
         self.expectationWillFinishLaunchingWithOption = expectationWillFinishLaunchingWithOption
-        self.expectationApplicationDidBecomeActive = expectationApplicationDidBecomeActive
-        self.expectationApplicationWillResignActive = expectationApplicationWillResignActive
-        self.expectationApplicationDidEnterBackground = expectationApplicationDidEnterBackground
-        self.expectationApplicationWillEnterForeground = expectationApplicationWillEnterForeground
         self.expectationApplicationWillTerminate = expectationApplicationWillTerminate
     }
 }
 
 
 final class LifecycleTests: XCTestCase {
+    @MainActor
     func testUIApplicationLifecycleMethods() async throws {
         let expectationWillFinishLaunchingWithOption = XCTestExpectation(description: "WillFinishLaunchingWithOptions")
-        let expectationApplicationDidBecomeActive = XCTestExpectation(description: "ApplicationDidBecomeActive")
-        let expectationApplicationWillResignActive = XCTestExpectation(description: "ApplicationWillResignActive")
-        let expectationApplicationDidEnterBackground = XCTestExpectation(description: "ApplicationDidEnterBackground")
-        let expectationApplicationWillEnterForeground = XCTestExpectation(description: "ApplicationWillEnterForeground")
         let expectationApplicationWillTerminate = XCTestExpectation(description: "ApplicationWillTerminate")
         
-        let testApplicationDelegate = await TestLifecycleHandlerApplicationDelegate(
+        let testApplicationDelegate = TestLifecycleHandlerApplicationDelegate(
             expectationWillFinishLaunchingWithOption: expectationWillFinishLaunchingWithOption,
-            expectationApplicationDidBecomeActive: expectationApplicationDidBecomeActive,
-            expectationApplicationWillResignActive: expectationApplicationWillResignActive,
-            expectationApplicationDidEnterBackground: expectationApplicationDidEnterBackground,
-            expectationApplicationWillEnterForeground: expectationApplicationWillEnterForeground,
             expectationApplicationWillTerminate: expectationApplicationWillTerminate
         )
         
-        let willFinishLaunchingWithOptions = try await testApplicationDelegate.application(
+        let willFinishLaunchingWithOptions = try testApplicationDelegate.application(
             UIApplication.shared,
             willFinishLaunchingWithOptions: [UIApplication.LaunchOptionsKey.url: XCTUnwrap(URL(string: "spezi.stanford.edu"))]
         )
         XCTAssertTrue(willFinishLaunchingWithOptions)
         wait(for: [expectationWillFinishLaunchingWithOption])
         
-        await testApplicationDelegate.applicationDidBecomeActive(UIApplication.shared)
-        wait(for: [expectationApplicationDidBecomeActive])
-        
-        await testApplicationDelegate.applicationWillResignActive(UIApplication.shared)
-        wait(for: [expectationApplicationWillResignActive])
-        
-        await testApplicationDelegate.applicationDidEnterBackground(UIApplication.shared)
-        wait(for: [expectationApplicationDidEnterBackground])
-        
-        await testApplicationDelegate.applicationWillEnterForeground(UIApplication.shared)
-        wait(for: [expectationApplicationWillEnterForeground])
-        
-        await testApplicationDelegate.applicationWillTerminate(UIApplication.shared)
+        testApplicationDelegate.applicationWillTerminate(UIApplication.shared)
         wait(for: [expectationApplicationWillTerminate])
     }
 }

--- a/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestComponent.swift
+++ b/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestComponent.swift
@@ -1,0 +1,51 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SwiftUI
+
+
+final class LifecycleHandlerTestComponent<ComponentStandard: Standard>: Module {
+    @AppStorage("willFinishLaunchingWithOptions") var willFinishLaunchingWithOptions: Int = 0
+    @AppStorage("sceneWillEnterForeground") var sceneWillEnterForeground: Int = 0
+    @AppStorage("sceneDidBecomeActive") var sceneDidBecomeActive: Int = 0
+    @AppStorage("sceneWillResignActive") var sceneWillResignActive: Int = 0
+    @AppStorage("sceneDidEnterBackground") var sceneDidEnterBackground: Int = 0
+    @AppStorage("applicationWillTerminate") var applicationWillTerminate: Int = 0
+    
+    
+    func willFinishLaunchingWithOptions(_ application: UIApplication, launchOptions: [UIApplication.LaunchOptionsKey: Any]) {
+        willFinishLaunchingWithOptions += 1
+        precondition(willFinishLaunchingWithOptions - 1 == applicationWillTerminate)
+    }
+    
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        sceneWillEnterForeground += 1
+        precondition(sceneWillEnterForeground - 1 == sceneDidBecomeActive)
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        sceneDidBecomeActive += 1
+        precondition(sceneWillEnterForeground == sceneDidBecomeActive)
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        sceneWillResignActive += 1
+        precondition(sceneWillResignActive - 1 == sceneDidEnterBackground)
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        sceneDidEnterBackground += 1
+        precondition(sceneWillResignActive == sceneDidEnterBackground)
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        applicationWillTerminate += 1
+        precondition(willFinishLaunchingWithOptions == applicationWillTerminate)
+    }
+}

--- a/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestsView.swift
+++ b/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestsView.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import XCTestApp
+import XCTSpezi
+
+
+struct LifecycleHandlerTestsView: View {
+    typealias LifecycleHandlerComponent = LifecycleHandlerTestComponent<TestAppStandard>
+    
+    
+    @EnvironmentObject var testAppComponent: LifecycleHandlerComponent
+    
+    
+    var body: some View {
+        VStack {
+            Text("WillFinishLaunchingWithOptions: \(testAppComponent.willFinishLaunchingWithOptions)")
+            Text("SceneWillEnterForeground: \(testAppComponent.sceneWillEnterForeground)")
+            Text("SceneDidBecomeActive: \(testAppComponent.sceneDidBecomeActive)")
+            Text("SceneWillResignActive: \(testAppComponent.sceneWillResignActive)")
+            Text("SceneDidEnterBackground: \(testAppComponent.sceneDidEnterBackground)")
+            Text("ApplicationWillTerminate: \(testAppComponent.applicationWillTerminate)")
+        }
+    }
+}

--- a/Tests/UITests/TestApp/Shared/FeatureFlags.swift
+++ b/Tests/UITests/TestApp/Shared/FeatureFlags.swift
@@ -1,0 +1,14 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// A collection of feature flags for the Spezi Test App app.
+enum FeatureFlags {
+    /// Run the lifecycleTests
+    static let lifecycleTests = CommandLine.arguments.contains("--lifecycleTests")
+}

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -14,6 +14,9 @@ import XCTSpezi
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: TestAppStandard()) {
+            // if FeatureFlags.lifecycleTests {
+                LifecycleHandlerTestComponent()
+            // }
             MultipleObservableObjectsTestsComponent()
             ObservableComponentTestsComponent(message: "Passed")
         }

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -14,9 +14,9 @@ import XCTSpezi
 class TestAppDelegate: SpeziAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: TestAppStandard()) {
-            // if FeatureFlags.lifecycleTests {
+            if FeatureFlags.lifecycleTests {
                 LifecycleHandlerTestComponent()
-            // }
+            }
             MultipleObservableObjectsTestsComponent()
             ObservableComponentTestsComponent(message: "Passed")
         }

--- a/Tests/UITests/TestApp/SpeziTests.swift
+++ b/Tests/UITests/TestApp/SpeziTests.swift
@@ -12,12 +12,15 @@ import XCTestApp
 
 enum SpeziTests: String, TestAppTests {
     case observableObject = "ObservableObject"
+    case lifecycleHandler = "LifecycleHandler"
     
     
     func view(withNavigationPath path: Binding<NavigationPath>) -> some View {
         switch self {
         case .observableObject:
             ObservableObjectTestsView()
+        case .lifecycleHandler:
+            LifecycleHandlerTestsView()
         }
     }
 }

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+import XCTestExtensions
+
+
+final class LifecycleHandlerTests: XCTestCase {
+    func testLifecycleHandler() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--lifecycleTests"]
+        app.deleteAndLaunch(withSpringboardAppName: "TestApp")
+        
+        app.staticTexts["LifecycleHandler"].tap()
+        
+        XCTAssert(app.staticTexts["WillFinishLaunchingWithOptions: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneWillEnterForeground: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneDidBecomeActive: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneWillResignActive: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneDidEnterBackground: 0"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["ApplicationWillTerminate: 0"].waitForExistence(timeout: 2))
+        
+        
+        let springBoard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        springBoard.activate()
+        app.activate()
+        
+        XCTAssert(app.staticTexts["WillFinishLaunchingWithOptions: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneWillEnterForeground: 2"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneDidBecomeActive: 2"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneWillResignActive: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["SceneDidEnterBackground: 1"].waitForExistence(timeout: 2))
+        XCTAssert(app.staticTexts["ApplicationWillTerminate: 0"].waitForExistence(timeout: 2))
+    }
+}

--- a/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
+++ b/Tests/UITests/UITests.xcodeproj/TestApp.xctestplan
@@ -9,6 +9,20 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:..\/..",
+          "identifier" : "Spezi",
+          "name" : "Spezi"
+        },
+        {
+          "containerPath" : "container:..\/..",
+          "identifier" : "XCTSpezi",
+          "name" : "XCTSpezi"
+        }
+      ]
+    },
     "targetForVariableExpansion" : {
       "containerPath" : "container:UITests.xcodeproj",
       "identifier" : "2F6D139128F5F384007C25D6",

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		2F9F07F129090B0500CDC598 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07F029090B0500CDC598 /* TestAppDelegate.swift */; };
 		2F9F07F529090BA900CDC598 /* ObservableObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07F429090BA900CDC598 /* ObservableObjectTests.swift */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
+		2FFDAD052A4AA9D300488F42 /* LifecycleHandlerTestsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD042A4AA9D300488F42 /* LifecycleHandlerTestsView.swift */; };
+		2FFDAD072A4AAA2E00488F42 /* LifecycleHandlerTestComponent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD062A4AAA2E00488F42 /* LifecycleHandlerTestComponent.swift */; };
+		2FFDAD092A4AAEF400488F42 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */; };
+		2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */; };
+		2FFDAD0D2A4AB0CE00488F42 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FFDAD0C2A4AB0CE00488F42 /* XCTestExtensions */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +52,10 @@
 		2FA7382B290ADFAA007ACEB9 /* TestApp.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
 		2FB926E42974B0FC008E7B03 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		2FC42FD7290ADD5E00B08F18 /* Spezi */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = Spezi; path = ../..; sourceTree = "<group>"; };
+		2FFDAD042A4AA9D300488F42 /* LifecycleHandlerTestsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTestsView.swift; sourceTree = "<group>"; };
+		2FFDAD062A4AAA2E00488F42 /* LifecycleHandlerTestComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTestComponent.swift; sourceTree = "<group>"; };
+		2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
+		2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +73,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FFDAD0D2A4AB0CE00488F42 /* XCTestExtensions in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -107,6 +117,7 @@
 			children = (
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
 				2F5FA4CD29E0A3BA0047A644 /* SpeziTests.swift */,
+				2FFDAD032A4AA99800488F42 /* LifecycleHandler */,
 				2F5FA4C029E0A1620047A644 /* ObservableObjectTests */,
 				2F9F07ED29090AF500CDC598 /* Shared */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
@@ -120,6 +131,7 @@
 			children = (
 				2FB926E42974B0FC008E7B03 /* Info.plist */,
 				2F9F07F429090BA900CDC598 /* ObservableObjectTests.swift */,
+				2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */,
 			);
 			path = TestAppUITests;
 			sourceTree = "<group>";
@@ -135,8 +147,18 @@
 			isa = PBXGroup;
 			children = (
 				2F9F07F029090B0500CDC598 /* TestAppDelegate.swift */,
+				2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */,
 			);
 			path = Shared;
+			sourceTree = "<group>";
+		};
+		2FFDAD032A4AA99800488F42 /* LifecycleHandler */ = {
+			isa = PBXGroup;
+			children = (
+				2FFDAD042A4AA9D300488F42 /* LifecycleHandlerTestsView.swift */,
+				2FFDAD062A4AAA2E00488F42 /* LifecycleHandlerTestComponent.swift */,
+			);
+			path = LifecycleHandler;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -180,6 +202,7 @@
 			);
 			name = TestAppUITests;
 			packageProductDependencies = (
+				2FFDAD0C2A4AB0CE00488F42 /* XCTestExtensions */,
 			);
 			productName = ExampleUITests;
 			productReference = 2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */;
@@ -274,9 +297,12 @@
 				2F5FA4C629E0A1620047A644 /* ObservableObjectTests.swift in Sources */,
 				2F5FA4CE29E0A3BA0047A644 /* SpeziTests.swift in Sources */,
 				2F5FA4C529E0A1620047A644 /* MultipleObservableObjectsTestsComponent.swift in Sources */,
+				2FFDAD092A4AAEF400488F42 /* FeatureFlags.swift in Sources */,
 				2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */,
 				2F5FA4C829E0A1620047A644 /* ObservableObjectTestsView.swift in Sources */,
 				2F9F07F129090B0500CDC598 /* TestAppDelegate.swift in Sources */,
+				2FFDAD072A4AAA2E00488F42 /* LifecycleHandlerTestComponent.swift in Sources */,
+				2FFDAD052A4AA9D300488F42 /* LifecycleHandlerTestsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -284,6 +310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */,
 				2F9F07F529090BA900CDC598 /* ObservableObjectTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -565,7 +592,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.0;
+				minimumVersion = 0.4.4;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -583,6 +610,11 @@
 		2F5FA4D129E0B38C0047A644 /* XCTSpezi */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XCTSpezi;
+		};
+		2FFDAD0C2A4AB0CE00488F42 /* XCTestExtensions */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2F746D9D29962B2A00BF54FE /* XCRemoteSwiftPackageReference "XCTestExtensions" */;
+			productName = XCTestExtensions;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -20,6 +20,34 @@
                ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "XCTSpezi"
+               BuildableName = "XCTSpezi"
+               BlueprintName = "XCTSpezi"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "Spezi"
+               BuildableName = "Spezi"
+               BlueprintName = "Spezi"
+               ReferencedContainer = "container:../..">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -139,12 +167,6 @@
             ReferencedContainer = "container:UITests.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "--firebaseAccount"
-            isEnabled = "NO">
-         </CommandLineArgument>
-      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -8,24 +8,24 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
-               BuildableName = "TestApp.app"
-               BlueprintName = "TestApp"
-               ReferencedContainer = "container:UITests.xcodeproj">
+               BlueprintIdentifier = "Spezi"
+               BuildableName = "Spezi"
+               BlueprintName = "Spezi"
+               ReferencedContainer = "container:../..">
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "XCTSpezi"
@@ -42,10 +42,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "Spezi"
-               BuildableName = "Spezi"
-               BlueprintName = "Spezi"
-               ReferencedContainer = "container:../..">
+               BlueprintIdentifier = "2F6D139128F5F384007C25D6"
+               BuildableName = "TestApp.app"
+               BlueprintName = "TestApp"
+               ReferencedContainer = "container:UITests.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>


### PR DESCRIPTION
# Update LifecycleHandler to Use Scene Methods

## :recycle: Current situation & Problem
- The current Lifecycle methods in the Spezi `LifecycleHandlers` are not properly called and do not reflect the latest advancements on iOS to use the `UISceneDelegate`

## :bulb: Proposed solution
- Deprecates the current application lifecycle methods in favor for scene-related methods
- Adds tests to test the lifecycle methods

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
