### PR TITLE
Add CI Build for Xcode 14

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,6 +23,12 @@ jobs:
       artifactname: Spezi-Package.xcresult
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: Spezi-Package
+  build:
+    name: Build Swift Package on Xcode 14
+    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    with:
+      runsonlabels: '["macos-13"]'
+      scheme: Spezi-Package
   buildandtestuitests:
     name: Build and Test UI Tests
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2


### PR DESCRIPTION
# Add CI tests for Xcode 14

## :recycle: Current situation & Problem
- Tests and builds are only performed for Xcode 15

## :bulb: Proposed solution
- Adds support to at least build the code base on Xcode 14 to validate the functionality until Xcode 15 is released to the public.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
