### PR TITLE
Separate Scene Delegate in Separate Class to Avoid Double Initialization

### DIFF
--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -65,6 +65,9 @@ open class SpeziAppDelegate: NSObject, UIApplicationDelegate, UISceneDelegate {
     }
     
     
+    private(set) static weak var appDelegate: SpeziAppDelegate?
+    
+    
     private(set) lazy var spezi: AnySpezi = configuration.spezi
     
     
@@ -107,7 +110,8 @@ open class SpeziAppDelegate: NSObject, UIApplicationDelegate, UISceneDelegate {
         options: UIScene.ConnectionOptions
     ) -> UISceneConfiguration {
         let sceneConfig = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
-        sceneConfig.delegateClass = Self.self
+        SpeziAppDelegate.appDelegate = self
+        sceneConfig.delegateClass = SpeziSceneDelegate.self
         return sceneConfig
     }
     

--- a/Sources/Spezi/Spezi/SpeziSceneDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziSceneDelegate.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+class SpeziSceneDelegate: NSObject, UISceneDelegate {
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        guard let delegate = SpeziAppDelegate.appDelegate else {
+            return
+        }
+        delegate.sceneWillEnterForeground(scene)
+    }
+    
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        guard let delegate = SpeziAppDelegate.appDelegate else {
+            return
+        }
+        delegate.sceneDidBecomeActive(scene)
+    }
+    
+    func sceneWillResignActive(_ scene: UIScene) {
+        guard let delegate = SpeziAppDelegate.appDelegate else {
+            return
+        }
+        delegate.sceneWillResignActive(scene)
+    }
+    
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        guard let delegate = SpeziAppDelegate.appDelegate else {
+            return
+        }
+        delegate.sceneDidEnterBackground(scene)
+    }
+}


### PR DESCRIPTION
# Separate Scene Delegate in Separate Class to Avoid Double Initialization

## :recycle: Current situation & Problem
- Adding a scene delegate in #67 introduced a bug where the app delegate was instantiated twice.

## :bulb: Proposed solution
- Separates out the functionality of handling the scene delegate in a separate class, avoiding double initializations


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
