### PR TITLE
Fix Permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,6 +26,7 @@ jobs:
   build:
     name: Build for CodeQL & Swift 5.7
     permissions:
+      contents: read
       security-events: write
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,8 @@ jobs:
       scheme: Spezi-Package
   build:
     name: Build for CodeQL & Swift 5.7
+    permissions:
+      security-events: write
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macos-13"]'


### PR DESCRIPTION
# Fix Permissions

## :recycle: Current situation & Problem
- Fixes the permissions that security reports were not reportable due to a missing GITHUB_TOKEN


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
