### PR TITLE
Support iteration in builtin SharedRepository implementations

### DIFF
--- a/Sources/Spezi/SharedRepository/Builtin/HeapRepository.swift
+++ b/Sources/Spezi/SharedRepository/Builtin/HeapRepository.swift
@@ -32,3 +32,25 @@ public final class HeapRepository<Anchor>: SharedRepository, BuiltinRepository {
         collect0(allOf: type)
     }
 }
+
+
+extension HeapRepository: Collection {
+    public typealias Index = Dictionary<ObjectIdentifier, AnyRepositoryValue>.Index
+
+    public var startIndex: Index {
+        storage.values.startIndex
+    }
+
+    public var endIndex: Index {
+        storage.values.endIndex
+    }
+
+    public func index(after index: Index) -> Index {
+        storage.values.index(after: index)
+    }
+
+
+    public subscript(position: Index) -> AnyRepositoryValue {
+        storage.values[position]
+    }
+}

--- a/Sources/Spezi/SharedRepository/Builtin/ValueRepository.swift
+++ b/Sources/Spezi/SharedRepository/Builtin/ValueRepository.swift
@@ -6,8 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Foundation
-
 
 /// A ``ValueRepository`` that allows to store any ``KnowledgeSource``s.
 public typealias UniversalValueRepository = ValueRepository<Any>

--- a/Sources/Spezi/SharedRepository/Builtin/ValueRepository.swift
+++ b/Sources/Spezi/SharedRepository/Builtin/ValueRepository.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import Foundation
+
 
 /// A ``ValueRepository`` that allows to store any ``KnowledgeSource``s.
 public typealias UniversalValueRepository = ValueRepository<Any>
@@ -31,6 +33,27 @@ public struct ValueRepository<Anchor>: SharedRepository, BuiltinRepository {
 
     public func collect<Value>(allOf type: Value.Type) -> [Value] {
         collect0(allOf: type)
+    }
+}
+
+extension ValueRepository: Collection {
+    public typealias Index = Dictionary<ObjectIdentifier, AnyRepositoryValue>.Index
+
+    public var startIndex: Index {
+        storage.values.startIndex
+    }
+
+    public var endIndex: Index {
+        storage.values.endIndex
+    }
+
+    public func index(after index: Index) -> Index {
+        storage.values.index(after: index)
+    }
+
+
+    public subscript(position: Index) -> AnyRepositoryValue {
+        storage.values[position]
     }
 }
 

--- a/Sources/Spezi/SharedRepository/RepositoryValue.swift
+++ b/Sources/Spezi/SharedRepository/RepositoryValue.swift
@@ -9,6 +9,8 @@
 
 /// Represents type erased ``RepositoryValue``.
 public protocol AnyRepositoryValue {
+    /// This property gives access to a type-erased version of ``RepositoryValue/Source``
+    var anySource: any KnowledgeSource.Type { get }
     /// This property gives access to a type-erased version of ``RepositoryValue/value``.
     var anyValue: Any { get }
 }
@@ -31,6 +33,11 @@ public protocol RepositoryValue<Source>: AnyRepositoryValue {
 
 
 extension RepositoryValue {
+    /// The type erased ``RepositoryValue/Source``.
+    public var anySource: any KnowledgeSource.Type {
+        Source.self
+    }
+
     /// The type erased ``RepositoryValue/value``.
     public var anyValue: Any {
         value

--- a/Tests/SpeziTests/HelperTests/SharedRepositoryTests.swift
+++ b/Tests/SpeziTests/HelperTests/SharedRepositoryTests.swift
@@ -265,6 +265,27 @@ final class SharedRepositoryTests: XCTestCase {
         Self.optionalComputedValue = nil
     }
 
+    func testValueRepositoryIteration() {
+        var repository = ValueRepository<TestAnchor>()
+        repository[TestStruct.self] = TestStruct(value: 3)
+        iterationTest(repository)
+    }
+
+    func testHeapRepositoryIteration() {
+        var repository = HeapRepository<TestAnchor>()
+        repository[TestStruct.self] = TestStruct(value: 3)
+        iterationTest(repository)
+    }
+
+    func iterationTest<Repository: SharedRepository<TestAnchor>>(_ repository: Repository)
+        where Repository: Collection, Repository.Element == AnyRepositoryValue {
+        for value in repository {
+            XCTAssertTrue(value.anySource is TestStruct.Type)
+            XCTAssertTrue(value.anyValue is TestStruct)
+            XCTAssertEqual(value.anyValue as? TestStruct, TestStruct(value: 3))
+        }
+    }
+
     func testSetAndGet() {
         repos.forEach { $0.testSetAndGet() }
     }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Support iteration in builtin SharedRepository implementations

## :recycle: Current situation & Problem
Currently, we have no ability to access the elements in our built in shared repositories in a type-erased way. Specifically, we have no way to iterate over them.

## :bulb: Proposed solution
This PR addresses this issue by adding `Collection` conformance for our two builtin Shared Repository types and extending the `AnyRepositoryValue` type.

## :gear: Release Notes 
* Add `Collection` conformance to our build in shared repositories.

## :heavy_plus_sign: Additional Information

### Related PRs
This feature will be useful in https://github.com/StanfordSpezi/SpeziAccount/pull/7 for a Account Service to process modified account details.

### Testing
Additionally unit tests were included.

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
