### PR TITLE
Optimize DocC bundle structure and update old code examples

### DIFF
--- a/Sources/Spezi/Capabilities/ObservableObject/ObservableObjectComponent.swift
+++ b/Sources/Spezi/Capabilities/ObservableObject/ObservableObjectComponent.swift
@@ -18,7 +18,7 @@ import SwiftUI
 /// A Component can conform to `ObservableObjectProvider` to inject `ObservableObject`s in the SwiftUI view hierarchy.
 /// You define all `ObservableObject`s that should be injected using the ``ObservableObjectProvider/observableObjects-3hktb`` property.
 /// ```swift
-/// class MyComponent<ComponentStandard: Standard>: ObservableObjectProvider {
+/// class MyComponent: ObservableObjectProvider {
 ///     public var observableObjects: [any ObservableObject] {
 ///         [/* ... */]
 ///     }
@@ -28,7 +28,7 @@ import SwiftUI
 /// `ObservableObjectProvider` provides a default implementation of the ``ObservableObjectProvider/observableObjects-3hktb`` If your type conforms to `ObservableObject`
 /// that just injects itself into the SwiftUI view hierarchy:
 /// ```swift
-/// class MyComponent<ComponentStandard: Standard>: ObservableObject, ObservableObjectProvider {
+/// class MyComponent: ObservableObject, ObservableObjectProvider {
 ///     @Published
 ///     var test: String
 ///
@@ -40,7 +40,7 @@ public protocol ObservableObjectProvider {
     ///
     /// You define all `ObservableObject`s that should be injected using the ``ObservableObjectProvider/observableObjects-3hktb`` property.
     /// ```swift
-    /// class MyComponent<ComponentStandard: Standard>: ObservableObjectProvider {
+    /// class MyComponent: ObservableObjectProvider {
     ///     public var observableObjects: [any ObservableObject] {
     ///         [/* ... */]
     ///     }

--- a/Sources/Spezi/Configuration/Configuration.swift
+++ b/Sources/Spezi/Configuration/Configuration.swift
@@ -42,6 +42,12 @@
 /// ```
 ///
 /// The ``Component`` documentation provides more information about the structure of components.
+///
+/// ## Topics
+///
+/// ### Result Builder
+/// - ``ComponentBuilder``
+/// - ``ComponentCollection``
 public struct Configuration {
     let spezi: AnySpezi
     

--- a/Sources/Spezi/Dependencies/Component+Dependencies.swift
+++ b/Sources/Spezi/Dependencies/Component+Dependencies.swift
@@ -12,14 +12,14 @@ extension Component {
     ///
     /// A ``Component`` can define the dependencies using the @``Component/Dependency`` property wrapper:
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Dependency var exampleComponentDependency = ExampleComponentDependency()
     /// }
     /// ```
     ///
     /// Some components do not need a default value assigned to the property if they provide a default configuration and conform to ``DefaultInitializable``.
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Dependency var exampleComponentDependency: ExampleComponentDependency
     /// }
     /// ```
@@ -36,7 +36,7 @@ extension Component {
     ///
     /// A ``Component`` can define dynamic dependencies using the @``Component/DynamicDependencies`` property wrapper and can, e.g., initialize its value in the initializer.
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @DynamicDependencies var dynamicDependencies: [any Component<ComponentStandard>]
     ///
     ///

--- a/Sources/Spezi/Module/Capabilities/Communication/CollectPropertyWrapper.swift
+++ b/Sources/Spezi/Module/Capabilities/Communication/CollectPropertyWrapper.swift
@@ -50,7 +50,7 @@ extension Component {
     /// Below is an example where the `ExampleComponent` collects an array of `Numeric` types from all other `Components`.
     ///
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Collect var favoriteNumbers: [Numeric]
     ///
     ///     func configure() {

--- a/Sources/Spezi/Module/Capabilities/Communication/ProvidePropertyWrapper.swift
+++ b/Sources/Spezi/Module/Capabilities/Communication/ProvidePropertyWrapper.swift
@@ -66,7 +66,7 @@ extension Component {
     ///
     /// Below is an example where the `ExampleComponent` provides a `Numeric` type to some other components.
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Provide var favoriteNumber: Numeric
     ///
     ///     init() {
@@ -80,7 +80,7 @@ extension Component {
     /// If `nil` is provided, nothing is collected, otherwise the underlying value of the optional is collected.
     ///
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Provide var favoriteNumber: Numeric?
     ///
     ///     init() {
@@ -95,7 +95,7 @@ extension Component {
     /// If you want to provide more than one instance of a given value you may declare @Provide as an `Array` type.
     ///
     /// ```swift
-    /// class ExampleComponent<ComponentStandard: Standard>: Component {
+    /// class ExampleComponent: Component {
     ///     @Provide var favoriteNumbers: [Numeric]
     ///
     ///     init() {

--- a/Sources/Spezi/SharedRepository/SharedRepository.swift
+++ b/Sources/Spezi/SharedRepository/SharedRepository.swift
@@ -70,7 +70,7 @@ public protocol SharedRepository<Anchor> {
 
     /// A subscript to retrieve a ``ComputedKnowledgeSource``.
     ///
-    /// - Note: This is the implementation for the ``ComputedKnowledgeSource/Store`` policy.
+    /// - Note: This is the implementation for the ``SomeComputedKnowledgeSource/Store`` policy.
     ///     If the value was not present and got computed, the computed value will be stored in the repository.
     /// - Parameter source: The ``ComputedKnowledgeSource`` type.
     /// - Returns: The stored ``KnowledgeSource/Value`` or calls ``ComputedKnowledgeSource/compute(from:)`` to compute the value.
@@ -79,7 +79,7 @@ public protocol SharedRepository<Anchor> {
 
     /// A subscript to retrieve a ``ComputedKnowledgeSource``.
     ///
-    /// - Note: This is the implementation for the ``ComputedKnowledgeSource/AlwaysCompute`` policy.
+    /// - Note: This is the implementation for the ``SomeComputedKnowledgeSource/AlwaysCompute`` policy.
     ///     The ``ComputedKnowledgeSource/compute(from:)`` method will always be called as a result of this subscript call.
     /// - Parameter source: The ``ComputedKnowledgeSource`` type.
     /// - Returns: The calls ``ComputedKnowledgeSource/compute(from:)`` to compute the value.
@@ -88,7 +88,7 @@ public protocol SharedRepository<Anchor> {
 
     /// A subscript to retrieve a ``OptionalComputedKnowledgeSource``.
     ///
-    /// - Note: This is the implementation for the ``OptionalComputedKnowledgeSource/Store`` policy.
+    /// - Note: This is the implementation for the ``SomeComputedKnowledgeSource/Store`` policy.
     ///     If the value was not present and got computed, the computed value will be stored in the repository.
     /// - Parameter source: The ``OptionalComputedKnowledgeSource`` type.
     /// - Returns: The stored ``KnowledgeSource/Value`` or calls ``OptionalComputedKnowledgeSource/compute(from:)`` to compute the value
@@ -98,7 +98,7 @@ public protocol SharedRepository<Anchor> {
 
     /// A subscript to retrieve a ``OptionalComputedKnowledgeSource``.
     ///
-    /// - Note: This is the implementation for the ``OptionalComputedKnowledgeSource/AlwaysCompute`` policy.
+    /// - Note: This is the implementation for the ``SomeComputedKnowledgeSource/AlwaysCompute`` policy.
     ///     The ``OptionalComputedKnowledgeSource/compute(from:)`` method will always be called as a result of this subscript call.
     /// - Parameter source: The ``OptionalComputedKnowledgeSource`` type.
     /// - Returns: The calls ``OptionalComputedKnowledgeSource/compute(from:)`` to compute the value

--- a/Sources/Spezi/Spezi.docc/Component.md
+++ b/Sources/Spezi/Spezi.docc/Component.md
@@ -60,7 +60,7 @@ evaluated by the ``DependencyManager``.
 > Note: Declaring a cyclic dependency will result in a runtime error. 
 
 ```swift
-class ExampleComponent<ComponentStandard: Standard>: Component {
+class ExampleComponent: Component {
     @Dependency var exampleComponentDependency = ExampleComponentDependency()
 }
 ```
@@ -80,11 +80,11 @@ Refer to the documentation of the property wrappers for a more detailed overview
 Below is a simple example of passing data between ``Component``s.
 
 ```swift
-class ComponentA<ComponentStandard: Standard>: Component {
+class ComponentA: Component {
     @Provide var someGreeting = "Hello World"
 }
 
-class ComponentB<ComponentStandard: Standard>: Component {
+class ComponentB: Component {
     @Collect var allGreetings: [String]
 
     func collect() {
@@ -111,6 +111,11 @@ All these protocols are combined in the ``Module`` protocol, making it an easy o
 - ``Component/Provide``
 - ``Component/Collect``
 - ``Component/StandardActor``
+
+### Capabilities
+
+- ``LifecycleHandler``
+- ``ObservableObjectProvider``
 
 ### Dependency
 

--- a/Sources/Spezi/Spezi.docc/Initial Setup.md
+++ b/Sources/Spezi/Spezi.docc/Initial Setup.md
@@ -1,4 +1,4 @@
-# Setup
+# Initial Setup
 
 <!--
                   
@@ -41,7 +41,7 @@ struct ExampleApp: App {
 A ``Configuration`` defines the ``Standard`` and ``Component``s that are used in a Spezi project.
 
 Ensure that your standard conforms to all protocols enforced by the ``Component``s. If your ``Component``s require protocol conformances
-you must add them to your custom type conforming to ``Standard`` and passed to the initializer or extend a prebuild standard.
+you must add them to your custom type conforming to ``Standard`` and passed to the initializer or extend a prebuilt standard.
 
 Use ``Configuration/init(_:)`` to use default empty standard instance only conforming to ``Standard`` if you do not use any ``Component`` requiring custom protocol conformances.
 
@@ -73,11 +73,3 @@ class ExampleAppDelegate: SpeziAppDelegate {
 ```
 
 The ``Component`` documentation provides more information about the structure of components.
-
-## Topics
-
-### Core Spezi Types
-
-- ``Spezi/Spezi``
-- ``SpeziAppDelegate``
-- ``Standard``

--- a/Sources/Spezi/Spezi.docc/Shared Repository.md
+++ b/Sources/Spezi/Spezi.docc/Shared Repository.md
@@ -40,7 +40,7 @@ This signifies to ``KnowledgeSource`` adopters, that their ``KnowledgeSource/Val
 
 > Warning: Due to Swift limitations, the ``ValueRepository`` implementation never checks if a given ``KnowledgeSource`` implementation actually has
     a value type that conforms to `Sendable`. Therefore, implementors should make sure that their ``KnowledgeSource/Value`` conforms to `Sendable`.
-    If you require to check for such a conformance, you may write a Wrapper around the ``ValueRepository``, replicating its interface.
+    If you are required to check for such a conformance, you may write a Wrapper around the ``ValueRepository``, replicating its interface.
 
 ## Topics
 
@@ -69,7 +69,7 @@ This signifies to ``KnowledgeSource`` adopters, that their ``KnowledgeSource/Val
 - ``Spezi/AnyRepositoryValue``
 - ``Spezi/SimpleRepositoryValue``
 
-### Computed Knowlegde Sources
+### Computed Knowledge Sources
 
 - ``Spezi/SomeComputedKnowledgeSource``
 - ``Spezi/ComputedKnowledgeSourceStoragePolicy``

--- a/Sources/Spezi/Spezi.docc/Spezi.md
+++ b/Sources/Spezi/Spezi.docc/Spezi.md
@@ -14,7 +14,7 @@ Open-source framework for rapid development of modern, interoperable digital hea
 
 ## Overview
 
-> Note: Refer to the <doc:Setup> instructions on how to integrate Spezi into your application!
+> Note: Refer to the <doc:Initial-Setup> instructions on how to integrate Spezi into your application!
 
 Spezi introduces a standards-based modular approach to building digital health applications. 
 A ``Standard`` defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
@@ -23,7 +23,7 @@ You can learn more about the ``Standard`` protocol and when it is advised to cre
 A ``Component`` defines a software subsystem providing distinct and reusable functionality.
 Components can use the constraint mechanism to enforce a set of requirements to the standard used in the Spezi-based software where the component is used.
 Components also define dependencies on each other to reuse functionality and can communicate with other components by offering and collecting information.
-They can also conform to different additional protocols to provide additional access to Spezi features, such lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
+They can also conform to different additional protocols to provide additional access to Spezi features, such as lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
 You can learn more about components in the <doc:Component> documentation.
 
 To simplify the creation of components, a common set of functionalities typically used by components is summarized in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable Spezi module.
@@ -38,33 +38,23 @@ Check out the [Stanford Biodesign Digital Health Group GitHub organization](), f
 
 ## Topics
 
-### Spezi Setup
-
-- <doc:Setup>
-- ``Spezi/Spezi``
-- ``SpeziAppDelegate``
-- ``Standard``
-
-### Component
-
-- ``Component``
-
-### Modules
-
-- ``Module``
-
 ### Configuration
 
+- <doc:Initial-Setup>
+- ``SwiftUI/View/spezi(_:)``
+- ``SpeziAppDelegate``
 - ``Configuration``
-- ``ComponentBuilder``
-- ``ComponentCollection``
+
+### Essential Concepts
+
+- ``Spezi/Spezi``
+- ``Standard``
+- ``Component``
+- ``Module``
 
 ### Shared Repository
 
 - <doc:Shared-Repository>
-- ``SharedRepository``
-- ``RepositoryAnchor``
-- ``KnowledgeSource``
 - ``SpeziAnchor``
 - ``SpeziStorage``
 

--- a/Sources/Spezi/Spezi.docc/Standard.md
+++ b/Sources/Spezi/Spezi.docc/Standard.md
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
 }
 
 Components can use the constraint mechanism to enforce a set of requirements to the ``Standard`` used in the Spezi-based software where the component is used.
-This mechanism follows a two-step process detailed in the component documentation: <doc:Component>.
+This mechanism follows a two-step process detailed in the component documentation: ``Component``.
 
 The constraints are defined using a protocol that conforms to the `Standard` protocol:
 
@@ -58,17 +58,7 @@ var configuration: Configuration {
 }
 ```
 
-> Note: You can learn more about setting up your application in the <doc:Setup> article. You can learn more about the ``Configuration`` in its type documentation.
+> Note: You can learn more about setting up your application in the <doc:Initial-Setup> article. You can learn more about the ``Configuration`` in its type documentation.
 
 You can always access the current ``Standard`` instance in your ``Component`` using the @``Component/StandardActor`` property wrapper.
 It is also available using the `@EnvironmentObject` property wrapper in your SwiftUI views.
-
-
-## Topics
-
-### Modules & Component Capabilities
-
-- ``Component``
-- ``Module``
-- ``LifecycleHandler``
-- ``ObservableObjectProvider``

--- a/Sources/Spezi/Standard/Standard.swift
+++ b/Sources/Spezi/Standard/Standard.swift
@@ -8,5 +8,5 @@
 
 
 // note: detailed documentation is provided as an article extension in the DocC bundle
-/// A ``Standard`` defines the key component that orchestrates the data flow in the applicatoin by meeting requirements defined by components.
+/// A ``Standard`` defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
 public protocol Standard: Actor, Component { }


### PR DESCRIPTION
<!--

This source file is part of the Stanford Spezi open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Optimize DocC bundle structure and update old code examples

## :recycle: Current situation & Problem
Currently, the documentation exposes still old code examples using the `Standard` as a generic argument for a `Component`. Secondly, the DocC bundle is currently rather unstructured, were certain sections are recursively nested into each other.


## :gear: Release Notes 
* Updated old code examples.
* Restructured the DocC bundle. Creating more clear sections and making use of the `See Also` section to link back to similar documentation.
* Additionally, fixed some broken references.

## :books: Documentation
All done in documentation. It is heavily advised to build the documentation yourself for the PR review process to better understand the changes.


## :white_check_mark: Testing
_Not applicable_


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
