### PR TITLE
Add Spezi & Documentation Guide

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,6 +32,7 @@ jobs:
     with:
       runsonlabels: '["macos-13"]'
       xcodeversion: '14.3.1'
+      destination: 'platform=iOS Simulator,name=iPhone 14 Pro'
       scheme: Spezi-Package
       test: false
       codeql: true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,7 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macos-13"]'
+      xcodeversion: '14.3.1'
       scheme: Spezi-Package
       test: false
       codeql: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -375,6 +375,7 @@ excluded: # paths to ignore during linting. Takes precedence over `included`.
   - .build
   - .swiftpm
   - .derivedData
+  - Tests/UITests/.derivedData
 
 closure_body_length: # Closure bodies should not span too many lines.
   - 35 # warning - default: 20

--- a/README.md
+++ b/README.md
@@ -16,37 +16,56 @@ SPDX-License-Identifier: MIT
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpezi%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/StanfordSpezi/Spezi)
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2FStanfordSpezi%2FSpezi%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/StanfordSpezi/Spezi)
 
-An open-source framework for the rapid development of modern, interoperable digital health applications.
+
+Open-source framework for rapid development of modern, interoperable digital health applications.
+
+## Overview
+
+> [!NOTE] 
+> Refer to the [Initial Setup](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/initial-setup) instructions on how to integrate Spezi into your application!
+
+Spezi introduces a standards-based modular approach to building digital health applications. 
+
+
+|![Screenshot displaying the UI of the onboarding module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziOnboarding/main/Sources/SpeziOnboarding/SpeziOnboarding.docc/Resources/ConsentView.png#gh-light-mode-only) ![Screenshot displaying the UI of the onboarding module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziOnboarding/main/Sources/SpeziOnboarding/SpeziOnboarding.docc/Resources/ConsentView~dark.png#gh-dark-mode-only)|![Screenshot displaying the UI of the contact module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziContact/main/Sources/SpeziContact/SpeziContact.docc/Resources/Overview.png#gh-light-mode-only) ![Screenshot displaying the UI of the contact module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziContact/main/Sources/SpeziContact/SpeziContact.docc/Resources/Overview~dark.png#gh-dark-mode-only)|![Screenshot displaying the UI of the questionnaire module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziQuestionnaire/main/Sources/SpeziQuestionnaire/SpeziQuestionnaire.docc/Resources/Overview.png#gh-light-mode-only) ![Screenshot displaying the UI of the questionnaire module.](https://raw.githubusercontent.com/StanfordSpezi/SpeziQuestionnaire/main/Sources/SpeziQuestionnaire/SpeziQuestionnaire.docc/Resources/Overview~dark.png#gh-dark-mode-only)
+|:--:|:--:|:--:|
+|[The Spezi Onboarding Module](https://github.com/StanfordSpezi/SpeziOnboarding)|[The Spezi Contract Module](https://github.com/StanfordSpezi/SpeziContact)|[The Spezi Questionnaire Module](https://github.com/StanfordSpezi/SpeziQuestionnaire)|
+
+The best way to get started and explore the functionality of Spezi is by taking a look at the [Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication). The application incorporates a wide variety of sophisticated modules and demonstrates the usage of these modules in a simple-to-use and easy-to-extend application.
+
+
+### An Ecosystem of Modules
+
+You can find a list of modules and reusable Swift Packages offered by the Spezi team at Stanford at [the Swift Package Index Stanford Spezi page](https://swiftpackageindex.com/StanfordSpezi).
+
+> [!NOTE] 
+> Spezi relies on an ecosystem of modules. Think about what modules you want to build and contribute to the open-source community! Refer to the [Spezi Guide](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/spezi-guide) and [Documentation Guide](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/documentation-guide) about the requirements for Spezi-based software components and the ``Component`` and ``Module`` documentation to learn more about building your modules.
+
+Learn more about Spezi at [spezi.stanford.edu](https://spezi.stanford.edu).
+Reach out to us on social media and use the [Stanford Spezi Discussion Forum](https://github.com/orgs/StanfordSpezi/discussions) to ask any Spezi-related questions or share the projects you built with Spezi.
+
+Check out the [Stanford Biodesign Digital Health GitHub organization](https://github.com/StanfordBDHG) and [Stanford Biodesign Digital Health website at bdh.stanford.edu](https://bdh.stanford.edu), for example, applications built with Spezi and some of our related open-source and research projects.
+
+
+### The Spezi Building Blocks
+
+> [!NOTE]
+> The [Spezi Guide](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/spezi-guide) and [Documentation Guide](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/documentation-guide) guides define the requirements for Spezi-based modules, including terminology, hints, and examples on structuring your Spezi module, Swift Package, and surrounding repository.
+
+A ``Standard`` defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
+You can learn more about the ``Standard`` protocol and when it is advised to create your own standard in your application in the [`Standard`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/standard) documentation.
+
+A ``Component`` defines a software subsystem providing distinct and reusable functionality.
+Components can use the constraint mechanism to enforce a set of requirements to the standard used in the Spezi-based software where the component is used.
+Components also define dependencies on each other to reuse functionality and can communicate with other components by offering and collecting information.
+They can also conform to different protocols to provide additional access to Spezi features, such as lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
+You can learn more about components in the [`Component`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/component) documentation.
+
+To simplify the creation of components, a common set of functionalities typically used by components is summarized in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable Spezi module.
+
 
 For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordSpezi/Spezi/documentation).
 
-## The Spezi Architecture
-
-Spezi introduces a standards-based modular approach to building digital health applications. 
-A 'Standard' defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
-You can learn more about the 'Standard' protocol and when it is advised to create your own standard in your application in the <doc:Standard> documentation.
-
-A 'Component' defines a software subsystem providing distinct and reusable functionality.
-Components can use the constraint mechanism to enforce a set of requirements to the standard used in the Spezi-based software where the component is used.
-Components also define dependencies on each other to reuse functionality and can communicate with other components by offering and collecting information.
-They can also conform to different additional protocols to provide additional access to Spezi features, such lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
-You can learn more about components in the <doc:Component> documentation.
-
-To simplify the creation of components, a common set of functionalities typically used by components is summarized in the 'Module' protocol, making it an easy one-stop solution to support all these different functionalities and build a capable Spezi module.
-
-> Note: Spezi relies on an ecosystem of modules. Think about what modules you want to build and contribute to the open-source community! Refer to 'Component' and 'Module' documentation to learn more about building your modules.
-
-You can find a list of modules and reusable Swift Packages offered by the Spezi team at Stanford at https://swiftpackageindex.com/StanfordSpezi.
-Learn more about Spezi at https://spezi.stanford.edu.
-Reach out to us on social media and use the [Stanford Spezi Discussion Forum](https://github.com/orgs/StanfordSpezi/discussions) to ask any Spezi-related questions or share the projects you built with Spezi.
-
-Check out the [Stanford Biodesign Digital Health Group GitHub organization](), for example, applications built with Spezi and some of our related open-source and research projects.
-
-The [API documentation](https://swiftpackageindex.com/StanfordSpezi/Spezi/documentation) includes a selector to switch between the different Swift Package Manager Targets, allowing you to explore the different modules that are included in the Spezi repository.
-
-## The Spezi Template Application
-
-The [Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication) provides a great starting point and example about using the different Spezi modules.
 
 ## Contributing
 
@@ -57,5 +76,5 @@ Contributions to this project are welcome. Please make sure to read the [contrib
 
 This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordSpezi/Spezi/tree/main/LICENSES) for more information.
 
-![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/FooterLight.png#gh-light-mode-only)
-![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/FooterDark.png#gh-dark-mode-only)
+![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/Footer.png#gh-light-mode-only)
+![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/Footer~dark.png#gh-dark-mode-only)

--- a/Sources/Spezi/Configuration/Configuration.swift
+++ b/Sources/Spezi/Configuration/Configuration.swift
@@ -7,7 +7,7 @@
 //
 
 
-/// A ``Configuration`` defines the ``Standard`` and ``Component``s that are used in a Spezi project.
+/// Defines the ``Standard`` and ``Component``s that are used in a Spezi project.
 ///
 /// Ensure that your standard conforms to all protocols enforced by the ``Component``s. If your ``Component``s require protocol conformances
 /// you must add them to your custom type conforming to ``Standard`` and passed to the initializer or extend a prebuild standard.

--- a/Sources/Spezi/Spezi.docc/Component.md
+++ b/Sources/Spezi/Spezi.docc/Component.md
@@ -114,6 +114,7 @@ All these protocols are combined in the ``Module`` protocol, making it an easy o
 
 ### Capabilities
 
+- ``Module``
 - ``LifecycleHandler``
 - ``ObservableObjectProvider``
 

--- a/Sources/Spezi/Spezi.docc/Documentation Guide.md
+++ b/Sources/Spezi/Spezi.docc/Documentation Guide.md
@@ -1,0 +1,162 @@
+# Documentation Guide
+
+<!--
+
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+Defines the documentation requirements for Spezi modules, including hints and examples on structuring the documentation your Spezi module, Swift Package, and repository.
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+> Important: This guide uses the terminology defined in the <doc:Spezi-Guide>.
+
+The module MUST conform to this guide within two months after changes have been published to be considered in conformance with this guide.
+
+The README and documentation of the [SpeziMockWebService module](https://github.com/StanfordSpezi/SpeziMockWebService) are good examples of how documentation can be structured and written.
+
+
+## Code Documentation
+
+Serves as general guidance for writing documentation.
+All public interfaces of a Spezi module MUST be documented with non-trivial documentation that SHOULD guide a wide variety of users on how to use the application programming interface (API).
+
+Text MUST be written in a neutral form in conformance to the [contribution guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md).
+Abbreviations SHOULD be expanded the first time they are used.
+Inline documentation SHOULD have real-world examples and links to relevant information outside of the Spezi ecosystem to read up on important concepts.
+
+The documentation MUST use appropriate [GitHub markdown syntax](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) and [DocC documentation formatting elements](https://www.swift.org/documentation/docc/formatting-your-documentation-content) to create documentation that is easy to understand and well structured. 
+
+Related types within the module MUST be linked using [markdown links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links) or [DocC links](https://www.swift.org/documentation/docc/formatting-your-documentation-content#Link-to-Symbols-and-Other-Content).
+Essential external types SHOULD be linked to, e.g., the Apple Documentation like the [`@State`](https://developer.apple.com/documentation/swiftui/state) property wrapper.
+
+Code examples MUST use proper syntax highlighting, e.g.,:
+````md
+```swift
+let name = "Paul"
+```
+````
+
+Elements like [notes and other asides](https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package) SHOULD be used.
+GitHub offers equal elements for README documents, e.g.:
+```md
+> [!IMPORTANT] 
+> An important element ...
+```
+The same elements should be used for the equivalent DocC-based documentation:
+```md
+> Important: An important element ...
+```
+
+You SHOULD use [`@_documentation(visibility: ...)`](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_documentationvisibility-) to hide elements from the documentation that should not appear in the public documentation.
+It is RECOMMENDED to use `@_documentation(visibility: internal)` to an `@_exported import` statement to ensure that all public symbols of the imported module are not exposed in the documentation of the Spezi module.
+
+You can learn more about DocC by reading the documentation or watching the DocC Apple World Wide Developer Conference (WWDC) videos:
+- [swift.org - DocC Documentation](https://www.swift.org/documentation/docc/#)
+- [WWDC 2023 - Create rich documentation with Swift-DocC](https://developer.apple.com/wwdc23/10244)
+- [WWDC 2022 - Improve the discoverability of your Swift-DocC content](https://developer.apple.com/wwdc22/110369)
+
+
+### Images
+
+All images MUST be available in dark and light mode.
+The document MUST be configured to automatically load the appropriate image, e.g., in markdown using
+```md
+![Example Image](https://raw.githubusercontent.com/StanfordSpezi/.github/main/Example.png#gh-light-mode-only)
+![Example Image](https://raw.githubusercontent.com/StanfordSpezi/.github/main/Example~dark.png#gh-dark-mode-only)
+```
+and using the [DocC Image naming schemes](https://developer.apple.com/documentation/docc/image#Provide-Image-Variants).
+
+User interface screenshots MUST include a device frame, e.g., using [ControlRoom](https://github.com/twostraws/ControlRoom) or other software solutions. The background of the images MUST be transparent to use the background color of the documentation document or README.
+
+
+### Landing Page
+
+The [landing page](https://www.swift.org/documentation/docc/documenting-a-swift-framework-or-package) of the documentation in DocC MUST contain an overview section.
+The overview section MUST include a compact package description and its core functionality.
+A developer MAY use bullet points, a table, or a textual description.
+
+If the module provides significant user interface (UI) components, it SHOULD display them in the README to provide visual guidance.
+The overview SHOULD include a graphical representation of the package's functionality, e.g., a UML diagram or some other visual guidance.
+
+The landing page MAY also include a code example.
+It MUST link to the main types relevant to the Spezi module and SHOULD provide some guidance to articles that guide the user to learn more about the module.
+
+
+### Articles
+
+More comprehensive module features SHOULD be explained in articles and extension files guiding developers on using the API and other functionality.
+You can learn more about adding supplemental content to a documentation in the [swift.org - Adding Supplemental Content to a Documentation Catalog article](https://www.swift.org/documentation/docc/adding-supplemental-content-to-a-documentation-catalog).
+
+
+## README
+
+The README of a Spezi Module is an essential first point of contact.
+It MUST include the following sections:
+- Header
+- Overview
+- Example
+- Footer
+A README may include additional sections after the overview and before the Footer section.
+The README SHOULD reuse the content of the landing page DocC documentation of the Spezi module. It MAY add context relevant to the GitHub repository compared to the automatically generated documentation.
+
+
+### Header
+
+The Header MUST display the most essential documentation for a Spezi Module, including:
+- GitHub badge to a GitHub Action verifying the current build status
+- CodeCov code coverage report
+- One-line description of the module.
+
+It is RECOMMENDED to include a:
+- DOI for scientific citations, e.g., using [Zenodo.org](zenodo.org)
+- Badges to the [Swift Package Index](https://swiftpackageindex.com) for Swift package-based Spezi modules to indicate the supported Swift version and operating systems.
+
+
+### Overview
+
+The overview section MUST be equivalent to the landing page overview section of the DocC documentation.
+It MAY make slight modifications to adjust for the different formatting possibilities.
+DocC links MUST be translated into links to the hosted documentation, e.g., on the [Swift Package Index](https://swiftpackageindex.com) using markdown links.
+
+
+### Example
+
+The example section MUST include one or more code examples or short guidance on using the Spezi Module.
+The examples MAY be taken out of the inline documentation or articles in the DocC documentation.
+It MUST provide some written guidance around the example.
+The example MUST provide a link to more information about the place where the documentation is hosted, e.g., on the [Swift Package Index](https://swiftpackageindex.com).
+
+E.g., a final sentence MAY look like this:
+```md
+For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordSpezi/Spezi/documentation).
+```
+
+### Footer
+
+The footer of all Spezi Modules MUST include a link to the contributing guidlines, code of conduct, and license information.
+All Spezi modules hosted in the StanfordSpezi GitHub organization MUST include the footer below.
+Other Spezi modules MAY use the same footer but MUST adjust it to link to their documents, e.g., contributing guidelines.
+```md
+## Contributing
+
+Contributions to this project are welcome. Please make sure to read the [contribution guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md) and the [contributor covenant code of conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) first.
+
+
+## License
+
+This project is licensed under the MIT License. See [Licenses](https://github.com/StanfordSpezi/Spezi/tree/main/LICENSES) for more information.
+
+![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/Footer.png#gh-light-mode-only)
+![Spezi Footer](https://raw.githubusercontent.com/StanfordSpezi/.github/main/assets/Footer~dark.png#gh-dark-mode-only)
+```
+
+## Further Details
+
+GitHub repository SHOULD include the main description of the Spezi module and SHOULD link to the hosted documentation, e.g., at the [Swift Package Index](https://swiftpackageindex.com) in the sidebar of the GitHub repo.
+GitHub tags like `Spezi` and others MAY be used to easily find the module on GitHub or the [Swift Package Index](https://swiftpackageindex.com).

--- a/Sources/Spezi/Spezi.docc/Spezi Guide.md
+++ b/Sources/Spezi/Spezi.docc/Spezi Guide.md
@@ -1,0 +1,106 @@
+# Spezi Guide
+
+<!--
+          
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+       
+-->
+
+Defines the requirements for Spezi modules, including hints and examples on structuring your Spezi module, Swift Package, and repository.
+
+
+The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+The following guide defines the following terminology:
+- **Module**: A module is the fundamental building block of the Spezi ecosystem. A module can range from standalone functionality using frameworks used in Spezi, such as Swift, SwiftUI, or interoperability standards, to being deeply embedded in Spezi and providing complex functionality, including user interfaces and data management. The simplest way to be integrated into Spezi is the Swift ``Component`` protocol or by providing more sophisticated functionality using the ``Module`` protocol. A module MAY use the ``Component`` or ``Module`` protocol but is not REQUIRED to do so. Some modules MAY provide functionality independent of the Spezi integration mechanisms. We generally refer to Spezi as a _modularized_ ecosystem.
+- **Component**: The term component can describe the technical functionality enabled by the ``Component`` protocol and is mostly used for technical definitions and discussions, while _module_ is considered an outwards facing and marketing-friendly term.
+- **Swift Package**: Each software component is embedded in a Swift Package. A Swift Package can include multiple Swift Package targets, components, and modules.
+- **Repository**: A repository is a collection of versioned files embedded in a version control system. The Spezi context contains a single Swift Package and other configuration files, such as a continuous integration (CI) setup. Repositories are typically hosted on GitHub but can also be hosted on other platforms.
+
+To be featured by the Spezi team, a module, as well as the surrounding Swift Package and repository, MUST conform to this guide.
+The definitive endorsement or feature of a Spezi module is determined by the Spezi core team.
+A module SHOULD be submitted for consideration by sharing it in the [Show & Tell section of the Stanford Spezi Discussions forum](https://github.com/orgs/StanfordSpezi/discussions/categories/show-and-tell).
+
+The module, as well as the surrounding Swift Package and repository, MUST conform to this guide within two months after changes have been published to be considered in conformance with this guide.
+
+Check out the [Swift Package Template](https://github.com/StanfordBDHG/SwiftPackageTemplate) as an example of a repository meeting the requirements of this document, including a continuous integration (CI) setup using [GitHub Actions](https://github.com/features/actions).
+
+
+## Repository Setup
+
+A repository MUST be in full conformance to the GitHub Community Standards, checked by the insights tab of your repository, e.g., the [Spezi Community Standards Insights](https://github.com/StanfordSpezi/Spezi/community).
+Feel free to link and use the Spezi community guidelines and other community standards of Spezi. P
+lease ensure you reference and credit the Spezi team if you reuse any setup.
+You can learn more about open-source best practices at the [Open Source Guides page](https://opensource.guide).
+
+The repository MUST follow the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) with automated safeguards before merging the code as defined in the sections below.
+
+The repository MUST use [semantic versioning](https://semver.org) and MUST have an initial version tagged using [GitHub releases](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+
+The repository MUST use a comprehensive `.gitignore` file at the root of the repo to ignore files that should not be committed in the repo, e.g., [shown in the Spezi repository]( https://github.com/StanfordSpezi/Spezi/blob/main/.gitignore).
+
+It is RECOMMENDED to use a `CONTRIBUTORS.md` file at the root of the repo to list the contributors to the module, e.g., [shown in the Spezi repository](https://github.com/StanfordSpezi/Spezi/blob/main/CONTRIBUTORS.md).
+It is RECOMMENDED to use a `CITATION.cff` file at the root of the repo to make it [possible to cite the repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files), e.g., [shown in the Spezi repository](https://github.com/StanfordSpezi/Spezi/blob/main/CITATION.cff).
+It is RECOMMENDED to use a tool to automatically generate digital object identifiers (DOIs) to release, e.g., using [zenodo.org](https://zenodo.org).
+
+
+## Spezi Usage
+
+A Spezi module MUST support the latest major Spezi version within two months after the release.
+The module MUST use Spezi built-in features and integrate into the ecosystem of modules in the [Stanford Spezi GitHub organization](https://github.com/StanfordSpezi).
+It is RECOMMENDED to contribute features to existing Spezi modules if they fit within the feature scope rather than creating a new module.
+
+Different distinct functionalities under the umbrella of a Spezi module SHOULD be separated out into different targets.
+
+
+## License & Open Source
+
+The repository and all code making up the module and Swift Package MUST use an [open-source license](https://choosealicense.com).
+It SHOULD use the [MIT license](https://choosealicense.com/licenses/mit/).
+
+The repository MUST conform to the [REUSE specification](https://reuse.software/spec/).
+The conformance MUST be automatically checked in accordance to automated checks in the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) in a pull request (PR) and on the main branch.
+This can be done, e.g., using the [REUSE tool](https://github.com/fsfe/reuse-tool) and the [Stanford BDHG REUSE reusable workflow](https://github.com/StanfordBDHG/.github#reuse).
+
+It is RECOMMENDED to copy the license in, e.g., a `LICENSE.md` file to the root of the repo to ensure that [GitHub can detect the license](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/licensing-a-repository).
+
+The repository SHOULD accept outside contributions and SHOULD review, accept, or decline PRs and issues in a timely manner.
+Stale projects MAY not be considered in conformance with the Spezi module guidelines.
+
+
+## Code Style
+
+The Spezi repository MUST have a comprehensive and detailed style guide defined by a configuration file and tool.
+It is RECOMMENDED to use [swiftlint](https://github.com/realm/SwiftLint) for Swift-related code style checks.
+
+It is RECOMMENDED using the [Stanford Spezi swiftlint configuration](https://github.com/StanfordSpezi/Spezi/blob/main/.swiftlint.yml).
+Changes to the configuration MAY be possible and are judged by the Spezi core team. 
+
+The code MUST conform to the defined code style.
+The conformance MUST be automatically checked in accordance with automated checks in the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) in a pull request (PR) and on the main branch.
+This can be done, e.g., using [swiftlint](https://github.com/realm/SwiftLint), the [Stanford BDHG SwiftLint GitHub Action](https://github.com/marketplace/actions/swiftlint-tool), and/or the [Stanford BDHG REUSE reusable workflow](https://github.com/StanfordBDHG/.github#reuse).
+
+
+## Testing
+
+The Spezi repository MUST incorporate an automated testing setup, including unit tests and user interface (UI) tests if applicable.
+
+The project code coverage MUST be automatically reported, e.g., using a tool like [codecov.io](https://about.codecov.io).
+The project MUST have a code coverage of at least 70% of the lines of code, excluding tests and examples.
+It is RECOMMENDED that at least 80% of the lines of code are covered using automated tests.
+
+The conformance MUST be automatically checked in accordance with automated checks in the [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) in a pull request (PR) and on the main branch.
+It is RECOMMENDED using [GitHub Actions](https://github.com/features/actions) and [codecov.io](https://about.codecov.io).
+The [Stanford BDHG Test Using Xcodebuild or Run Fastlane reusable workflow](https://github.com/StanfordBDHG/.github#test-using-xcodebuild-or-run-fastlane) and [Stanford BDHG Merge and Upload Coverage Report reusable workflow](https://github.com/StanfordBDHG/.github#merge-and-upload-coverage-report) MAY be used to automate your setup..
+
+
+## Documentation
+
+The repository and all code making up the module and Swift Package MUST conform to the <doc:Documentation-Guide>.
+The documentation MUST be hosted and accessible based on the content of the repository.
+It is RECOMMENDED using the [Swift Package Index](https://swiftpackageindex.com).
+It is RECOMMENDED to use a `.spi.yml` file at the root of the repo to [configure the Swift Package Index setup](https://blog.swiftpackageindex.com/posts/the-swift-package-index-metadata-file-first-steps/) e.g., [shown in the Spezi repository](https://github.com/StanfordSpezi/Spezi/blob/main/.spi.yml).

--- a/Sources/Spezi/Spezi.docc/Spezi.md
+++ b/Sources/Spezi/Spezi.docc/Spezi.md
@@ -14,27 +14,62 @@ Open-source framework for rapid development of modern, interoperable digital hea
 
 ## Overview
 
-> Note: Refer to the <doc:Initial-Setup> instructions on how to integrate Spezi into your application!
+> Tip: Refer to the <doc:Initial-Setup> instructions on how to integrate Spezi into your application!
 
 Spezi introduces a standards-based modular approach to building digital health applications. 
+
+
+<!--
+Unfortunately, DocC currently does not support dark mode images: https://github.com/apple/swift-docc/pull/359#issuecomment-1214405608
+-->
+@Row {
+    @Column {
+        @Image(source: "https://raw.githubusercontent.com/StanfordSpezi/SpeziOnboarding/main/Sources/SpeziOnboarding/SpeziOnboarding.docc/Resources/ConsentView.png", alt: "Screenshot displaying the UI of the onboarding module.") {
+            [The Spezi Onboarding Module](https://github.com/StanfordSpezi/SpeziOnboarding)
+        }
+    }
+    @Column {
+        @Image(source: "https://raw.githubusercontent.com/StanfordSpezi/SpeziContact/main/Sources/SpeziContact/SpeziContact.docc/Resources/Overview.png", alt: "Screenshot displaying the UI of the contact module.") {
+            [The Spezi Contract Module](https://github.com/StanfordSpezi/SpeziContact)
+        }
+    }
+    @Column {
+        @Image(source: "https://raw.githubusercontent.com/StanfordSpezi/SpeziQuestionnaire/main/Sources/SpeziQuestionnaire/SpeziQuestionnaire.docc/Resources/Overview.png", alt: "Screenshot displaying the UI of the questionnaire module.") {
+            [The Spezi Questionnaire Module](https://github.com/StanfordSpezi/SpeziQuestionnaire)
+        }
+    }
+}
+
+The best way to get started and explore the functionality of Spezi is by taking a look at the [Spezi Template Application](https://github.com/StanfordSpezi/SpeziTemplateApplication). The application incorporates a wide variety of sophisticated modules and demonstrates the usage of these modules in a simple-to-use and easy-to-extend application.
+
+
+### An Ecosystem of Modules
+
+You can find a list of modules and reusable Swift Packages offered by the Spezi team at Stanford at [the Swift Package Index Stanford Spezi page](https://swiftpackageindex.com/StanfordSpezi).
+
+> Note: Spezi relies on an ecosystem of modules. Think about what modules you want to build and contribute to the open-source community! Refer to the <doc:Spezi-Guide> and <doc:Documentation-Guide> about the requirements for Spezi-based software components and the ``Component`` and ``Module`` documentation to learn more about building your modules.
+
+Learn more about Spezi at [spezi.stanford.edu](https://spezi.stanford.edu).
+Reach out to us on social media and use the [Stanford Spezi Discussion Forum](https://github.com/orgs/StanfordSpezi/discussions) to ask any Spezi-related questions or share the projects you built with Spezi.
+
+Check out the [Stanford Biodesign Digital Health GitHub organization](https://github.com/StanfordBDHG) and [Stanford Biodesign Digital Health website at bdh.stanford.edu](https://bdh.stanford.edu), for example, applications built with Spezi and some of our related open-source and research projects.
+
+
+### The Spezi Building Blocks
+
+> Tip: The <doc:Spezi-Guide> and <doc:Documentation-Guide> guides define the requirements for Spezi-based modules, including terminology, hints, and examples on structuring your Spezi module, Swift Package, and surrounding repository.
+
 A ``Standard`` defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
 You can learn more about the ``Standard`` protocol and when it is advised to create your own standard in your application in the <doc:Standard> documentation.
 
 A ``Component`` defines a software subsystem providing distinct and reusable functionality.
 Components can use the constraint mechanism to enforce a set of requirements to the standard used in the Spezi-based software where the component is used.
 Components also define dependencies on each other to reuse functionality and can communicate with other components by offering and collecting information.
-They can also conform to different additional protocols to provide additional access to Spezi features, such as lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
+They can also conform to different protocols to provide additional access to Spezi features, such as lifecycle management and triggering view updates in SwiftUI using the observable mechanisms in Swift.
 You can learn more about components in the <doc:Component> documentation.
 
 To simplify the creation of components, a common set of functionalities typically used by components is summarized in the ``Module`` protocol, making it an easy one-stop solution to support all these different functionalities and build a capable Spezi module.
 
-> Note: Spezi relies on an ecosystem of modules. Think about what modules you want to build and contribute to the open-source community! Refer to ``Component`` and ``Module`` documentation to learn more about building your modules.
-
-You can find a list of modules and reusable Swift Packages offered by the Spezi team at Stanford at https://swiftpackageindex.com/StanfordSpezi.
-Learn more about Spezi at https://spezi.stanford.edu.
-Reach out to us on social media and use the [Stanford Spezi Discussion Forum](https://github.com/orgs/StanfordSpezi/discussions) to ask any Spezi-related questions or share the projects you built with Spezi.
-
-Check out the [Stanford Biodesign Digital Health Group GitHub organization](), for example, applications built with Spezi and some of our related open-source and research projects.
 
 ## Topics
 
@@ -47,6 +82,8 @@ Check out the [Stanford Biodesign Digital Health Group GitHub organization](), f
 
 ### Essential Concepts
 
+- <doc:Spezi-Guide>
+- <doc:Documentation-Guide>
 - ``Spezi/Spezi``
 - ``Standard``
 - ``Component``
@@ -62,3 +99,4 @@ Check out the [Stanford Biodesign Digital Health Group GitHub organization](), f
 
 - ``AnyArray``
 - ``AnyOptional``
+ 

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 
-/// The ``SpeziAppDelegate`` is used to configure the Spezi-based application using the ``SpeziAppDelegate/configuration`` property.
+/// Configure the Spezi-based application using the ``SpeziAppDelegate/configuration`` property.
 ///
 /// Set up the Spezi framework in your `App` instance of your SwiftUI application using the ``SpeziAppDelegate`` and the `@UIApplicationDelegateAdaptor` property wrapper.
 /// Use the `View.spezi(_: SpeziAppDelegate)` view modifier to apply your Spezi configuration to the main view in your SwiftUI `Scene`:

--- a/Sources/Spezi/Standard/Standard.swift
+++ b/Sources/Spezi/Standard/Standard.swift
@@ -8,5 +8,5 @@
 
 
 // note: detailed documentation is provided as an article extension in the DocC bundle
-/// A ``Standard`` defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
+/// Defines the key component that orchestrates the data flow in the application by meeting requirements defined by components.
 public protocol Standard: Actor, Component { }


### PR DESCRIPTION
# Add Spezi & Documentation Guide

## :recycle: Current situation & Problem
- The Spezi & Documentation Guides are currently in the .github repo and not easy to quickly read and share as part of the Spezi Documentation
- The initial README of Spezi could be improved to make it more approachable.


## :gear: Release Notes 
- Improves the documentation
- Reworks the DocC landing page and README
- Adds the Spezi & Documentation Guide


## :books: Documentation
- Documentation is improved throughout the project.



## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
