### PR TITLE
Introduce EnvironmentAccessible

### DIFF
--- a/Sources/Spezi/Capabilities/Observable/EnvironmentAccessible.swift
+++ b/Sources/Spezi/Capabilities/Observable/EnvironmentAccessible.swift
@@ -1,0 +1,38 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+/// Places a ``Module`` into the SwiftUI environment.
+///
+/// Below is a short code example how you would declare an environment accessible module,
+/// and how to access it within SwiftUI, if it is configured in your ``Configuration``.
+///
+/// ```swift
+/// public class ExampleModule: Module, EnvironmentAccessible {
+///     // ... implement your functionality
+/// }
+///
+///
+/// struct ExampleView: View {
+///     @Environment(ExampleModule.self) var module
+///
+///     var body: some View {
+///         // ... access module functionality
+///     }
+/// }
+/// ```
+public protocol EnvironmentAccessible: AnyObject, Observable {}
+
+
+extension EnvironmentAccessible {
+    var viewModifier: any ViewModifier {
+        ModelModifier(model: self)
+    }
+}

--- a/Sources/Spezi/Capabilities/ViewModifier/ModifierPropertyWrapper.swift
+++ b/Sources/Spezi/Capabilities/ViewModifier/ModifierPropertyWrapper.swift
@@ -15,7 +15,7 @@ public class _ModifierPropertyWrapper<Modifier: ViewModifier> {
     // swiftlint:disable:previous type_name
     // We want the type to be hidden from autocompletion and documentation generation
 
-    private var storedValue: Modifier
+    private var storedValue: Modifier?
     private var collected = false
 
 
@@ -23,7 +23,10 @@ public class _ModifierPropertyWrapper<Modifier: ViewModifier> {
     /// - Note: You cannot access the value once it was collected.
     public var wrappedValue: Modifier {
         get {
-            storedValue
+            guard let storedValue else {
+                preconditionFailure("@Modifier was accessed before it was initialized for the first time.")
+            }
+            return storedValue
         }
         set {
             precondition(!collected, "You cannot update a @Modifier property after it was already collected.")
@@ -31,6 +34,9 @@ public class _ModifierPropertyWrapper<Modifier: ViewModifier> {
         }
     }
 
+
+    /// Initialize a new `@Modifier` property wrapper.
+    public init() {}
 
     /// Initialize a new `@Modifier` property wrapper.
     /// - Parameter wrappedValue: The initial value.
@@ -69,8 +75,14 @@ extension Module {
 
 
 extension _ModifierPropertyWrapper: ViewModifierProvider {
-    var viewModifier: any ViewModifier {
+    var viewModifier: (any ViewModifier)? {
         collected = true
+
+        guard let storedValue else {
+            assertionFailure("@Modifier with type \(Modifier.self) was collected but no value was provided!")
+            return nil
+        }
+
         return storedValue
     }
 }

--- a/Sources/Spezi/Capabilities/ViewModifier/ViewModifierProvider.swift
+++ b/Sources/Spezi/Capabilities/ViewModifier/ViewModifierProvider.swift
@@ -22,7 +22,9 @@ enum ModifierPlacement: Int, Comparable {
 /// [`ViewModifier`](https://developer.apple.com/documentation/swiftui/viewmodifier) to be injected into the global view hierarchy.
 protocol ViewModifierProvider {
     /// The view modifier instance that should be injected into the SwiftUI view hierarchy.
-    var viewModifier: any ViewModifier { get }
+    ///
+    /// Does nothing if `nil` is provided.
+    var viewModifier: (any ViewModifier)? { get }
 
     /// Defines the placement order of this view modifier.
     ///
@@ -47,7 +49,7 @@ extension Module {
             .sorted { lhs, rhs in
                 lhs.placement < rhs.placement
             }
-            .map { provider in
+            .compactMap { provider in
                 provider.viewModifier
             }
     }

--- a/Sources/Spezi/Spezi.docc/Module.md
+++ b/Sources/Spezi/Spezi.docc/Module.md
@@ -142,13 +142,11 @@ class ExampleModule: Module {
 - ``Module/Provide``
 - ``Module/Collect``
 
-### Managing Model state
+### Interaction with SwiftUI
 
 - ``Module/Model``
-
-### Modifying the View hierarchy
-
 - ``Module/Modifier``
+- ``EnvironmentAccessible``
 
 ### Lifecycle Handling
 

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -95,6 +95,11 @@ public actor Spezi<S: Standard>: AnySpezi {
             module.storeModule(into: &storage)
 
             collectedModifiers.append(contentsOf: module.viewModifiers)
+
+            // If a module is @Observable, we automatically inject it view the `ModelModifier` into the environment.
+            if let observable = module as? EnvironmentAccessible {
+                collectedModifiers.append(observable.viewModifier)
+            }
         }
 
         self.storage = storage

--- a/Tests/UITests/TestApp/ModelTests/ModuleWithModel.swift
+++ b/Tests/UITests/TestApp/ModelTests/ModuleWithModel.swift
@@ -27,17 +27,23 @@ class MyModel2 {
 private struct MyModifier: ViewModifier {
     @Environment(MyModel2.self)
     var model
+    @Environment(ModuleWithModel.self)
+    var module
 
     func body(content: Content) -> some View {
         content
-            .environment(\.customKey, model.message == "Hello World")
+            .environment(\.customKey, model.message == "Hello World" && module.message == "MODEL")
     }
 }
 
 
-class ModuleWithModel: Module {
+class ModuleWithModel: Module, EnvironmentAccessible {
     @Model var model = MyModel2(message: "Hello World")
-    @Modifier fileprivate var modifier = MyModifier() // ensure reordering happens, ViewModifier must be able to access the model from environment
+
+    // ensure reordering happens, ViewModifier must be able to access the model from environment
+    @Modifier fileprivate var modifier = MyModifier()
+
+    let message: String = "MODEL"
 }
 
 


### PR DESCRIPTION
# Introduce EnvironmentAccessible

## :recycle: Current situation & Problem
 
As of right now, it is not easy to access a Component directly within your SwiftUI views. This approach is, e.g., used within SpeziStorage to make its API easy accessible.
We introduce the `EnvironmentAccessible` protocol that allows a Module to be accessed from the environment just like an `Observable`. Further, we optimized `@Modifier` and `@Model` to allow for later initialization.

## :gear: Release Notes 
 
* Introduce `EnvironmentAccessible` protocol.
* Allow for delayed initialization of `@Modifier` and `@Model`.


## :books: Documentation
* Documentation was added. 
 
## :white_check_mark: Testing
New functionality was tested.
 


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
