### PR TITLE
Improve support for Previews and Unit Testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,8 @@ let package = Package(
         .library(name: "XCTSpezi", targets: ["XCTSpezi"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", .upToNextMinor(from: "0.2.5"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.0"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions", from: "1.0.0")
     ],
     targets: [
         .target(

--- a/Sources/Spezi/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
+++ b/Sources/Spezi/Capabilities/Lifecycle/Spezi+LifecycleHandlers.swift
@@ -12,7 +12,7 @@ import SwiftUI
 
 extension AnySpezi {
     /// A collection of ``Spezi/Spezi`` `LifecycleHandler`s.
-    private var lifecycleHandler: [LifecycleHandler] {
+    var lifecycleHandler: [LifecycleHandler] {
         storage.collect(allOf: LifecycleHandler.self)
     }
     

--- a/Sources/Spezi/Configuration/Configuration.swift
+++ b/Sources/Spezi/Configuration/Configuration.swift
@@ -10,7 +10,7 @@
 /// Defines the ``Standard`` and ``Module``s that are used in a Spezi project.
 ///
 /// Ensure that your standard conforms to all protocols enforced by the ``Module``s. If your ``Module``s require protocol conformances
-/// you must add them to your custom type conforming to ``Standard`` and passed to the initializer or extend a prebuild standard.
+/// you must add them to your custom type conforming to ``Standard`` and passed to the initializer or extend a prebuilt standard.
 ///
 /// Use ``Configuration/init(_:)`` to use default empty standard instance only conforming to ``Standard`` if you do not use any ``Module`` requiring custom protocol conformances.
 ///
@@ -18,9 +18,8 @@
 /// The following example demonstrates the usage of an `ExampleStandard` standard and reusable Spezi modules, including the `HealthKit` and `QuestionnaireDataSource` modules:
 /// ```swift
 /// import Spezi
-/// import HealthKit
-/// import HealthKitDataSource
-/// import Questionnaires
+/// import SpeziHealthKit
+/// import SpeziOnboarding
 /// import SwiftUI
 ///
 ///
@@ -35,7 +34,7 @@
 ///                     )
 ///                 }
 ///             }
-///             QuestionnaireDataSource()
+///             OnboardingDataSource()
 ///         }
 ///     }
 /// }

--- a/Sources/Spezi/Spezi.docc/Spezi.md
+++ b/Sources/Spezi/Spezi.docc/Spezi.md
@@ -107,5 +107,7 @@ To simplify the creation of modules, a common set of functionalities typically u
 
 ### Previews
 
-- ``SwiftUI/View/spezi(standard:_:)``
-- ``SwiftUI/View/spezi(_:)-8giv6``
+- ``SwiftUI/View/previewWith(standard:simulateLifecycle:_:)``
+- ``SwiftUI/View/previewWith(simulateLifecycle:_:)``
+- ``Foundation/ProcessInfo/isPreviewSimulator``
+- ``LifecycleSimulationOptions``

--- a/Sources/Spezi/Spezi.docc/Spezi.md
+++ b/Sources/Spezi/Spezi.docc/Spezi.md
@@ -93,9 +93,9 @@ To simplify the creation of modules, a common set of functionalities typically u
 ### Configuration
 
 - <doc:Initial-Setup>
-- ``SwiftUI/View/spezi(_:)``
 - ``SpeziAppDelegate``
 - ``Configuration``
+- ``SwiftUI/View/spezi(_:)-3bn89``
 
 ### Essential Concepts
 
@@ -104,4 +104,8 @@ To simplify the creation of modules, a common set of functionalities typically u
 - ``Spezi/Spezi``
 - ``Standard``
 - ``Module``
- 
+
+### Previews
+
+- ``SwiftUI/View/spezi(standard:_:)``
+- ``SwiftUI/View/spezi(_:)-8giv6``

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -1,0 +1,77 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+import XCTRuntimeAssertions
+
+
+/// Options to simulate behavior for a ``LifecycleHandler`` in cases where there is no app delegate like in Preview setups.
+public enum LifecycleSimulationOptions {
+    /// Simulation is disabled.
+    case disabled
+    /// The ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-8jatp`` method will be called for all
+    /// configured ``Module``s that conform to ``LifecycleHandler``.
+    case launchWithOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any])
+
+    static let launchWithOptions: LifecycleSimulationOptions = .launchWithOptions([:])
+}
+
+
+extension View {
+    /// Configure Spezi for your previews using a Standard and a collection of Modules.
+    ///
+    /// This modifier can be used to configure Spezi with a Standard a collection of Modules without declaring a ``SpeziAppDelegate``.
+    ///
+    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
+    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///
+    /// - Parameters:
+    ///   - standard: The global  ``Standard`` used throughout the app to manage global data flow.
+    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
+    ///   - modules: The ``Module``s used in the Spezi project.
+    /// - Returns: The configured view using the Spezi framework.
+    public func previewWith<S: Standard>(
+        standard: S,
+        simulateLifecycle: LifecycleSimulationOptions = .disabled,
+        @ModuleBuilder _ modules: () -> ModuleCollection
+    ) -> some View {
+        precondition(
+            ProcessInfo.processInfo.isPreviewSimulator,
+            "The Spezi previewWith(standard:_:) modifier can only used within Xcode preview processes."
+        )
+
+        let spezi = Spezi(standard: standard, modules: modules().elements)
+        let lifecycleHandlers = spezi.lifecycleHandler
+
+        return modifier(SpeziViewModifier(spezi))
+            .task {
+                if case let .launchWithOptions(options) = simulateLifecycle {
+                    await lifecycleHandlers.willFinishLaunchingWithOptions(UIApplication.shared, launchOptions: options)
+                }
+            }
+    }
+
+    /// Configure Spezi for your previews using a collection of Modules.
+    ///
+    /// This modifier can be used to configure Spezi with a collection of Modules without declaring a ``SpeziAppDelegate``.
+    ///
+    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
+    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///
+    /// - Parameters:
+    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
+    ///   - modules: The ``Module``s used in the Spezi project.
+    /// - Returns: The configured view using the Spezi framework.
+    public func previewWith(
+        simulateLifecycle: LifecycleSimulationOptions = .disabled,
+        @ModuleBuilder _ modules: () -> ModuleCollection
+    ) -> some View {
+        previewWith(standard: DefaultStandard(), simulateLifecycle: simulateLifecycle, modules)
+    }
+}

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -29,11 +29,12 @@ extension View {
     /// This modifier can be used to configure Spezi with a Standard a collection of Modules without declaring a ``SpeziAppDelegate``.
     ///
     /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
-    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///     functionality, using ``LifecycleHandler``,  of modules is not fully supported. You may use the `simulateLifecycle`
+    ///     parameter to simulate a call to ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-8jatp``.
     ///
     /// - Parameters:
     ///   - standard: The global  ``Standard`` used throughout the app to manage global data flow.
-    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
+    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s. Disabled by default.
     ///   - modules: The ``Module``s used in the Spezi project.
     /// - Returns: The configured view using the Spezi framework.
     public func previewWith<S: Standard>(
@@ -62,10 +63,11 @@ extension View {
     /// This modifier can be used to configure Spezi with a collection of Modules without declaring a ``SpeziAppDelegate``.
     ///
     /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
-    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///     functionality, using ``LifecycleHandler``,  of modules is not fully supported. You may use the `simulateLifecycle`
+    ///     parameter to simulate a call to ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-8jatp``.
     ///
     /// - Parameters:
-    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
+    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s. Disabled by default.
     ///   - modules: The ``Module``s used in the Spezi project.
     /// - Returns: The configured view using the Spezi framework.
     public func previewWith(

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -9,6 +9,7 @@
 import Dispatch
 import Foundation
 import SwiftUI
+import XCTRuntimeAssertions
 
 
 struct SpeziViewModifier: ViewModifier {
@@ -45,8 +46,12 @@ extension View {
     ///   - standard: The global ``Standard`` used throughout the app to manage global data flow.
     ///   - modules: The ``Module``s used in the Spezi project.
     /// - Returns: The configured view using the Spezi framework.
-    public func spezi<S: Standard>(standard: S, @ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
-        modifier(SpeziViewModifier(Spezi(standard: standard, modules: modules().elements)))
+    public func previewWith<S: Standard>(standard: S, @ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
+        precondition(
+            ProcessInfo.processInfo.isPreviewSimulator,
+            "The Spezi previewWith(standard:_:) modifier can only used within Xcode preview processes."
+        )
+        return modifier(SpeziViewModifier(Spezi(standard: standard, modules: modules().elements)))
     }
 
     /// Configure Spezi for your previews using a collection of Modules.
@@ -58,8 +63,8 @@ extension View {
     ///
     /// - Parameter modules: The ``Module``s used in the Spezi project.
     /// - Returns: The configured view using the Spezi framework.
-    public func spezi(@ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
-        spezi(standard: DefaultStandard(), modules)
+    public func previewWith(@ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
+        previewWith(standard: DefaultStandard(), modules)
     }
 }
 

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -27,11 +27,39 @@ struct SpeziViewModifier: ViewModifier {
 
 
 extension View {
-    /// Use the `spezi()` `View` modifier to configure Spezi for your application.
-    /// - Parameter delegate: The `SpeziAppDelegate` used in the SwiftUI `App` instance.
-    /// - Returns: A SwiftUI view configured using the Spezi framework
+    /// Configure Spezi for your application using a delegate.
+    /// - Parameter delegate: The ``SpeziAppDelegate`` used in the SwiftUI App instance.
+    /// - Returns: The configured view using the Spezi framework.
     public func spezi(_ delegate: SpeziAppDelegate) -> some View {
         modifier(SpeziViewModifier(delegate.spezi))
+    }
+
+    /// Configure Spezi for your previews using a Standard and a collection of Modules.
+    ///
+    /// This modifier can be used to configure Spezi with a Standard a collection of Modules without declaring a ``SpeziAppDelegate``.
+    ///
+    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
+    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///
+    /// - Parameters:
+    ///   - standard: The global ``Standard`` used throughout the app to manage global data flow.
+    ///   - modules: The ``Module``s used in the Spezi project.
+    /// - Returns: The configured view using the Spezi framework.
+    public func spezi<S: Standard>(standard: S, @ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
+        modifier(SpeziViewModifier(Spezi(standard: standard, modules: modules().elements)))
+    }
+
+    /// Configure Spezi for your previews using a collection of Modules.
+    ///
+    /// This modifier can be used to configure Spezi with a collection of Modules without declaring a ``SpeziAppDelegate``.
+    ///
+    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
+    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
+    ///
+    /// - Parameter modules: The ``Module``s used in the Spezi project.
+    /// - Returns: The configured view using the Spezi framework.
+    public func spezi(@ModuleBuilder _ modules: () -> ModuleCollection) -> some View {
+        spezi(standard: DefaultStandard(), modules)
     }
 }
 

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -61,7 +61,7 @@ extension View {
         simulateLifecycle: LifecycleSimulationOptions = .disabled,
         @ModuleBuilder _ modules: () -> ModuleCollection
     ) -> some View {
-        let _ = precondition(
+        precondition(
             ProcessInfo.processInfo.isPreviewSimulator,
             "The Spezi previewWith(standard:_:) modifier can only used within Xcode preview processes."
         )

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 import SwiftUI
-import XCTRuntimeAssertions
 
 
 struct SpeziViewModifier: ViewModifier {
@@ -26,73 +25,12 @@ struct SpeziViewModifier: ViewModifier {
 }
 
 
-/// Options to simulate behavior for a ``LifecycleHandler`` in cases where there is no app delegate like in Preview setups.
-public enum LifecycleSimulationOptions {
-    /// Simulation is disabled.
-    case disabled
-    /// The ``LifecycleHandler/willFinishLaunchingWithOptions(_:launchOptions:)-8jatp`` method will be called for all
-    /// configured ``Module``s that conform to ``LifecycleHandler``.
-    case launchWithOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any])
-}
-
-
 extension View {
     /// Configure Spezi for your application using a delegate.
     /// - Parameter delegate: The ``SpeziAppDelegate`` used in the SwiftUI App instance.
     /// - Returns: The configured view using the Spezi framework.
     public func spezi(_ delegate: SpeziAppDelegate) -> some View {
         modifier(SpeziViewModifier(delegate.spezi))
-    }
-
-    /// Configure Spezi for your previews using a Standard and a collection of Modules.
-    ///
-    /// This modifier can be used to configure Spezi with a Standard a collection of Modules without declaring a ``SpeziAppDelegate``.
-    ///
-    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
-    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
-    ///
-    /// - Parameters:
-    ///   - standard: The global  ``Standard`` used throughout the app to manage global data flow.
-    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
-    ///   - modules: The ``Module``s used in the Spezi project.
-    /// - Returns: The configured view using the Spezi framework.
-    public func previewWith<S: Standard>(
-        standard: S,
-        simulateLifecycle: LifecycleSimulationOptions = .disabled,
-        @ModuleBuilder _ modules: () -> ModuleCollection
-    ) -> some View {
-        precondition(
-            ProcessInfo.processInfo.isPreviewSimulator,
-            "The Spezi previewWith(standard:_:) modifier can only used within Xcode preview processes."
-        )
-
-        let spezi = Spezi(standard: standard, modules: modules().elements)
-        let lifecycleHandlers = spezi.lifecycleHandler
-
-        return modifier(SpeziViewModifier(spezi))
-            .task {
-                if case let .launchWithOptions(options) = simulateLifecycle {
-                    await lifecycleHandlers.willFinishLaunchingWithOptions(UIApplication.shared, launchOptions: options)
-                }
-            }
-    }
-
-    /// Configure Spezi for your previews using a collection of Modules.
-    ///
-    /// This modifier can be used to configure Spezi with a collection of Modules without declaring a ``SpeziAppDelegate``.
-    ///
-    /// - Important: This modifier is only recommended for Previews. As it doesn't configure a ``SpeziAppDelegate`` lifecycle handling
-    ///     functionality, using ``LifecycleHandler``,  of modules won't work.
-    ///
-    /// - Parameters:
-    ///   - simulateLifecycle: Options to simulate behavior for ``LifecycleHandler``s.
-    ///   - modules: The ``Module``s used in the Spezi project.
-    /// - Returns: The configured view using the Spezi framework.
-    public func previewWith(
-        simulateLifecycle: LifecycleSimulationOptions = .disabled,
-        @ModuleBuilder _ modules: () -> ModuleCollection
-    ) -> some View {
-        previewWith(standard: DefaultStandard(), simulateLifecycle: simulateLifecycle, modules)
     }
 }
 

--- a/Sources/Spezi/Utilities/ProcessInfo+PreviewSimulator.swift
+++ b/Sources/Spezi/Utilities/ProcessInfo+PreviewSimulator.swift
@@ -1,0 +1,20 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension ProcessInfo {
+    static let xcodeRunningForPreviewKey = "XCODE_RUNNING_FOR_PREVIEWS"
+
+
+    /// Check if the current process is running in a simulator inside a Xcode preview.
+    public var isPreviewSimulator: Bool {
+        environment[Self.xcodeRunningForPreviewKey] == "1"
+    }
+}

--- a/Sources/XCTSpezi/DependencyResolution.swift
+++ b/Sources/XCTSpezi/DependencyResolution.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import Spezi
+@_implementationOnly import SwiftUI
+
+
+/// Configure and resolve the dependency tree for a collection of [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module)s.
+///
+/// This method can be used in unit test to resolve dependencies and properly initialize a set of Spezi `Module`s.
+///
+/// - Parameters:
+///   - standard: The Spezi [`Standard`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/standard) to initialize.
+///   - simulateLifecycle: Options to simulate behavior for [`LifecycleHandler`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/lifecyclehandler)s.
+///   - modules: The collection of Modules that are configured.
+public func withDependencyResolution<S: Standard>(
+    standard: S,
+    simulateLifecycle: LifecycleSimulationOptions = .disabled,
+    @ModuleBuilder _ modules: () -> ModuleCollection
+) {
+    let spezi = Spezi(standard: standard, modules: modules().elements)
+
+    if case let .launchWithOptions(options) = simulateLifecycle {
+        spezi.lifecycleHandler.willFinishLaunchingWithOptions(UIApplication.shared, launchOptions: options)
+    }
+}
+
+/// Configure and resolve the dependency tree for a collection of [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module)s.
+///
+/// This method can be used in unit test to resolve dependencies and properly initialize a set of Spezi `Module`s.
+///
+/// - Parameters:
+///   - simulateLifecycle: Options to simulate behavior for [`LifecycleHandler`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/lifecyclehandler)s.
+///   - modules: The collection of Modules that are configured.
+public func withDependencyResolution(
+    simulateLifecycle: LifecycleSimulationOptions = .disabled,
+    @ModuleBuilder _ modules: () -> ModuleCollection
+) {
+    withDependencyResolution(standard: DefaultStandard(), simulateLifecycle: simulateLifecycle, modules)
+}

--- a/Sources/XCTSpezi/TestAppStandard.swift
+++ b/Sources/XCTSpezi/TestAppStandard.swift
@@ -1,9 +1,0 @@
-//
-// This source file is part of the Stanford Spezi open-source project
-//
-// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
-//
-// SPDX-License-Identifier: MIT
-//
-
-import Spezi

--- a/Sources/XCTSpezi/XCTSpezi.docc/XCTSpezi.md
+++ b/Sources/XCTSpezi/XCTSpezi.docc/XCTSpezi.md
@@ -1,0 +1,46 @@
+# ``XCTSpezi``
+
+<!--
+
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT
+
+-->
+
+Test functionality for the Spezi framework.
+
+## Overview
+
+This package provides several testing extensions for the Spezi framework.
+
+
+### Testing Modules
+
+Unit test are particularly useful to test the behavior of a Spezi [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module)
+without building a complete SwiftUI App and testing functionality via UI Tests.
+However, it might be required to resolve and configure dependencies of a `Module` before it is usable.
+To do so, you can use ``withDependencyResolution(standard:simulateLifecycle:_:)`` or ``withDependencyResolution(simulateLifecycle:_:)``.
+Below is a short code example that demonstrates this functionality.
+
+```swift
+import XCTSpezi
+
+let module = ModuleUnderTest()
+
+// resolves all dependencies and configures your module ...
+withDependencyResolution {
+    module
+}
+
+// unit test your module ...
+```
+
+## Topics
+
+### Modules
+
+- ``withDependencyResolution(standard:simulateLifecycle:_:)``
+- ``withDependencyResolution(simulateLifecycle:_:)``

--- a/Tests/SpeziTests/ModuleTests/ModuleTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleTests.swift
@@ -23,4 +23,31 @@ final class ModuleTests: XCTestCase {
         )
         wait(for: [expectation])
     }
+
+    func testPreviewModifier() throws {
+        let expectation = XCTestExpectation(description: "Preview Module")
+        expectation.assertForOverFulfill = true
+
+        // manually patch environment variable for running within Xcode preview window
+        setenv(ProcessInfo.xcodeRunningForPreviewKey, "1", 1)
+
+        _ = try XCTUnwrap(
+            Text("Spezi")
+                .previewWith {
+                    TestModule(expectation: expectation)
+                }
+        )
+        wait(for: [expectation])
+
+        unsetenv(ProcessInfo.xcodeRunningForPreviewKey)
+    }
+
+    func testPreviewModifierOnlyWithinPreview() throws {
+        try XCTRuntimePrecondition {
+            _ = Text("Spezi")
+                .previewWith {
+                    TestModule()
+                }
+        }
+    }
 }


### PR DESCRIPTION
# Improve support for Previews and Unit Testing

## :recycle: Current situation & Problem
As outlined in #63, there is a need to more easily configure the Spezi framework within SwiftUI Previews. This currently is not easily possible, as we require an `SpeziAppDelegate` to be configured to support infrastructure like the `LifecycleHandler` protocol. This is not available for Previews.

This PR adds two new shorthand `previewWith(simulateLifecycle:_:)` and `previewWith(standard:simulateLifecycle:_:)` modifiers that are targeted for preview usage only. As documented, `LifecycleHandler` are not  fully supported with this configuration due to the missing App delegate. However, there is an option to partially simulate its behavior.

Further, #64 illustrates difficulties to unit test Spezi `Modules` due to missing abilities to resolve Module dependencies without initializing a SwiftUI App. This PR adds first-hand support for this scenario using the methods `withDependencyResolution(simulateLifecycle:_:)` and `withDependencyResolution(standard:simulateLifecycle:_:)` in the `XCTSpezi` package.

## :gear: Release Notes 
* Add new `previewWith(simulateLifecycle:_:)` and `previewWith(standard:simulateLifecycle:_:)` modifiers to be used within SwiftUI Previews.
* Add new `withDependencyResolution(simulateLifecycle:_:)` and `withDependencyResolution(standard:simulateLifecycle:_:)` methods to support unit testing Spezi Modules.


## :books: Documentation
Documentation was added to illustrate that these modifiers should only be used within Previews. Further, they are placed in a dedicated `Previews` section in the DocC landing page.

New DocC bundle was added for the XCTSpezi target.


## :white_check_mark: Testing
Several test cases were added to support this new functionality.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
