### PR TITLE
Remove access to application launch options via @Application on macOS

### DIFF
--- a/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
+++ b/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
@@ -9,6 +9,7 @@
 import SpeziFoundation
 import SwiftUI
 
+
 struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
     typealias Anchor = SpeziAnchor
 
@@ -16,7 +17,7 @@ struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
     typealias Value = [UIApplication.LaunchOptionsKey: Any]
 #elseif os(macOS)
     /// Currently not supported as ``SpeziAppDelegate/applicationWillFinishLaunching(_:)`` on macOS
-    /// is called after the initialization of ``Spezi`` via `View/spezi(_:)` is done, breaking our precondition assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
+    /// is executed after the initialization of ``Spezi`` via `View/spezi(_:)` is done, breaking our initialization assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
     typealias Value = [Never: Any]
 #else // os(watchOS)
     typealias Value = [Never: Any]

--- a/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
+++ b/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
@@ -15,7 +15,9 @@ struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
 #if os(iOS) || os(visionOS) || os(tvOS)
     typealias Value = [UIApplication.LaunchOptionsKey: Any]
 #elseif os(macOS)
-    typealias Value = [AnyHashable: Any]
+    /// Currently not supported as ``SpeziAppDelegate/applicationWillFinishLaunching(_:)`` on macOS
+    /// is called after the initialization of ``Spezi`` via `View/spezi(_:)` is done, breaking our precondition assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
+    typealias Value = [Never: Any]
 #else // os(watchOS)
     typealias Value = [Never: Any]
 #endif
@@ -48,17 +50,7 @@ extension Spezi {
     public var launchOptions: [UIApplication.LaunchOptionsKey: Any] {
         storage[LaunchOptionsKey.self]
     }
-#elseif os(macOS)
-    /// The launch options of the application.
-    ///
-    /// You can access the launch options within your `configure()` method of your ``Module`` or ``Standard``.
-    ///
-    /// - Note: For more information refer to the documentation of
-    ///     [`applicationWillFinishLaunching(_:)`](https://developer.apple.com/documentation/appkit/nsapplicationdelegate/1428623-applicationwillfinishlaunching).
-    public var launchOptions: [AnyHashable: Any] {
-        storage[LaunchOptionsKey.self]
-    }
-#else // os(watchOS)
+#else // os(watchOS) || os(macOS)
     /// The launch options of the application on platforms that don't support launch options.
     public var launchOptions: [Never: Any] {
         storage[LaunchOptionsKey.self]

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -20,7 +20,7 @@ public enum LifecycleSimulationOptions {
     case launchWithOptions(_ launchOptions: [UIApplication.LaunchOptionsKey: Any])
 #elseif os(macOS)
     /// Injects the ``Spezi/launchOptions`` property to be accessed via the `@Application` property wrapper.
-    case launchWithOptions(_ launchOptions: [AnyHashable: Any])
+    case launchWithOptions(_ launchOptions: [Never: Any])
 #else // os(watchOS)
     /// Injects the ``Spezi/launchOptions`` property to be accessed via the `@Application` property wrapper.
     case launchWithOptions(_ launchOptions: [Never: Any])

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -124,12 +124,6 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
             return // see note above for why we don't launch this within the preview simulator!
         }
 
-        precondition(_spezi == nil, "\(#function) was called when Spezi was already initialized. Unable to pass options!")
-
-        var storage = SpeziStorage()
-        storage[LaunchOptionsKey.self] = notification.userInfo
-        self._spezi = Spezi(from: configuration, storage: storage)
-
         setupNotificationDelegate()
     }
 #elseif os(watchOS)

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -34,7 +34,7 @@ final class LifecycleHandlerTests: XCTestCase {
         let chrome = XCUIApplication(bundleIdentifier: "com.apple.RealityChrome")
         XCTAssert(chrome.buttons["CloseButton"].exists)
         chrome.buttons["CloseButton"].tap()
-        sleep(1)
+        sleep(3)
         app.activate()
         #elseif !os(macOS)
         let homeScreen = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)


### PR DESCRIPTION
# Remove access to application launch options via @Application on macOS

## :recycle: Current situation & Problem
The current version of Spezi crashes when using the `ApplicationDelegateAdaptor` with the `.spezi()` view modifier on macOS platforms. This results from a broken assumption about the initialization order upon Spezi bootup on macOS (not Catalyst!): The `.spezi()` view modifier is evaluated (and therefore `Spezi` initialized) before `SpeziAppDelegate/applicationWillFinishLaunching()` is called. 
This currently leads to a `precondition` failure on macOS within `SpeziAppDelegate/applicationWillFinishLaunching()` as `Spezi` is already initialized. 

Background: We initialize `Spezi` on macOS within the `SpeziAppDelegate/applicationWillFinishLaunching()` so that the application launch options are accessible via `@Application` (`@Application(\.launchOptions)`).

We noticed that error when lifting the SpeziSpeech module to visionOS & macOS: https://github.com/StanfordSpezi/SpeziSpeech/pull/5

## :gear: Release Notes 
- Remove access to application launch options via @Application on macOS, fixing a crash upon Spezi initialization


## :books: Documentation
Adjusted documentation in line about not supporting launch options on macOS anymore


## :white_check_mark: Testing
Manual testing 


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
