### PR TITLE
Migrate to @_spi instead of @testable

### DIFF
--- a/Sources/Spezi/Module/ModuleCollection.swift
+++ b/Sources/Spezi/Module/ModuleCollection.swift
@@ -11,8 +11,9 @@
 ///
 /// You can not create a ``ModuleCollection`` yourself. Please use the ``ModuleBuilder`` to create a ``ModuleCollection``.
 public class ModuleCollection {
-    let elements: [any Module]
-    
+    @_spi(Spezi)
+    public let elements: [any Module]
+
     
     init(elements: [any Module]) {
         self.elements = elements

--- a/Sources/Spezi/Module/ModuleCollection.swift
+++ b/Sources/Spezi/Module/ModuleCollection.swift
@@ -11,6 +11,7 @@
 ///
 /// You can not create a ``ModuleCollection`` yourself. Please use the ``ModuleBuilder`` to create a ``ModuleCollection``.
 public class ModuleCollection {
+    /// The elements of the collection.
     @_spi(Spezi)
     public let elements: [any Module]
 

--- a/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
+++ b/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
@@ -9,21 +9,21 @@
 import SpeziFoundation
 import SwiftUI
 
-
-struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
-    typealias Anchor = SpeziAnchor
+@_spi(Spezi)
+public struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
+    public typealias Anchor = SpeziAnchor
 
 #if os(iOS) || os(visionOS) || os(tvOS)
-    typealias Value = [UIApplication.LaunchOptionsKey: Any]
+    public typealias Value = [UIApplication.LaunchOptionsKey: Any]
 #elseif os(macOS)
     /// Currently not supported as ``SpeziAppDelegate/applicationWillFinishLaunching(_:)`` on macOS
     /// is executed after the initialization of ``Spezi`` via `View/spezi(_:)` is done, breaking our initialization assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
-    typealias Value = [Never: Any]
+    public typealias Value = [Never: Any]
 #else // os(watchOS)
-    typealias Value = [Never: Any]
+    public typealias Value = [Never: Any]
 #endif
 
-    static let defaultValue: Value = [:]
+    public static let defaultValue: Value = [:]
 }
 
 

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -109,6 +109,13 @@ public class Spezi {
         self.init(standard: configuration.standard, modules: configuration.modules.elements, storage: storage)
     }
     
+
+    /// Create a new Spezi instance.
+    ///
+    /// - Parameters:
+    ///   - standard: The standard to use.
+    ///   - modules: The collection of modules to initialize.
+    ///   - storage: Optional, initial storage to inject.
     @_spi(Spezi)
     public init(
         standard: any Standard,

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -91,7 +91,8 @@ public class Spezi {
     )
 
 
-    var lifecycleHandler: [LifecycleHandler] {
+    @_spi(Spezi)
+    public var lifecycleHandler: [LifecycleHandler] {
         storage.collect(allOf: LifecycleHandler.self)
     }
 
@@ -108,7 +109,8 @@ public class Spezi {
         self.init(standard: configuration.standard, modules: configuration.modules.elements, storage: storage)
     }
     
-    init(
+    @_spi(Spezi)
+    public init(
         standard: any Standard,
         modules: [any Module],
         storage: consuming SpeziStorage = SpeziStorage()

--- a/Sources/Spezi/Standard/DefaultStandard.swift
+++ b/Sources/Spezi/Standard/DefaultStandard.swift
@@ -7,4 +7,7 @@
 //
 
 
-actor DefaultStandard: Standard {}
+@_spi(Spezi)
+public actor DefaultStandard: Standard {
+    public init() {}
+}

--- a/Sources/XCTSpezi/DependencyResolution.swift
+++ b/Sources/XCTSpezi/DependencyResolution.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import Spezi
-@_implementationOnly import SwiftUI
+@_spi(Spezi) import Spezi
+import SwiftUI
 
 
 /// Configure and resolve the dependency tree for a collection of [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module)s.

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import Spezi
+@testable @_spi(Spezi) import Spezi
 import XCTest
 import XCTRuntimeAssertions
 


### PR DESCRIPTION
# Migrate to @_spi instead of @testable

## :recycle: Current situation & Problem
Currently, we use `@testable` within `XCTSpezi` to access the internal interface of `Spezi`. This introduces complications for people using `XCTSpezi`. Using @_spi is also better as we have a reduced interface that we expose and even allow for others to leverage the same power when accessing the System Programming Interface.


## :gear: Release Notes 
* Fixed an issue where compilation fails in certain test environments.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
