### PR TITLE
Fix visibility of NotificationHandler default implementations and make Delegate methods open

### DIFF
--- a/Sources/Spezi/Capabilities/Notifications/NotificationHandler.swift
+++ b/Sources/Spezi/Capabilities/Notifications/NotificationHandler.swift
@@ -79,10 +79,12 @@ extension NotificationHandler {
     }
 
 #if !os(macOS)
+    /// Empty default implementation.
     public func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) async -> BackgroundFetchResult {
         .noData
     }
 #else
+    /// Empty default implementation.
     public func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) {}
 #endif
 }

--- a/Sources/Spezi/Capabilities/Notifications/NotificationHandler.swift
+++ b/Sources/Spezi/Capabilities/Notifications/NotificationHandler.swift
@@ -70,19 +70,19 @@ public protocol NotificationHandler {
 extension NotificationHandler {
 #if !os(tvOS)
     /// Empty default implementation.
-    func handleNotificationAction(_ response: UNNotificationResponse) async {}
+    public func handleNotificationAction(_ response: UNNotificationResponse) async {}
 #endif
 
     /// Empty default implementation.
-    func receiveIncomingNotification(_ notification: UNNotification) async -> UNNotificationPresentationOptions? {
+    public func receiveIncomingNotification(_ notification: UNNotification) async -> UNNotificationPresentationOptions? {
         nil
     }
 
 #if !os(macOS)
-    func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) async -> BackgroundFetchResult {
+    public func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) async -> BackgroundFetchResult {
         .noData
     }
 #else
-    func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) {}
+    public func receiveRemoteNotification(_ remoteNotification: [AnyHashable: Any]) {}
 #endif
 }

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -90,7 +90,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
 
 #if os(iOS) || os(visionOS) || os(tvOS)
     @available(*, deprecated, message: "Propagate deprecation warning.")
-    public func application(
+    open func application(
         _ application: UIApplication,
         // The usage of an optional collection is impossible to avoid as the function signature is defined by the `UIApplicationDelegate`
         // swiftlint:disable:next discouraged_optional_collection
@@ -127,7 +127,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
         setupNotificationDelegate()
     }
 #elseif os(watchOS)
-    public func applicationDidFinishLaunching() {
+    open func applicationDidFinishLaunching() {
         guard !ProcessInfo.processInfo.isPreviewSimulator else {
             return // see note above for why we don't launch this within the preview simulator!
         }
@@ -139,7 +139,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
 
     // MARK: - Notifications
 
-    public func application(_ application: _Application, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    open func application(_ application: _Application, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         MainActor.assumeIsolated { // on macOS there is a missing MainActor annotation
             RegisterRemoteNotificationsAction.handleDeviceTokenUpdate(spezi, deviceToken)
 
@@ -150,7 +150,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
         }
     }
 
-    public func application(_ application: _Application, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+    open func application(_ application: _Application, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         MainActor.assumeIsolated { // on macOS there is a missing MainActor annotation
             RegisterRemoteNotificationsAction.handleFailedRegistration(spezi, error)
         }
@@ -186,20 +186,20 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate {
 #endif
 
 #if os(iOS) || os(visionOS) || os(tvOS)
-    public func application(
+    open func application(
         _ application: UIApplication,
         didReceiveRemoteNotification userInfo: [AnyHashable: Any]
     ) async -> UIBackgroundFetchResult {
         await handleReceiveRemoteNotification(userInfo)
     }
 #elseif os(macOS)
-    public func application(_ application: NSApplication, didReceiveRemoteNotification userInfo: [String: Any]) {
+    open func application(_ application: NSApplication, didReceiveRemoteNotification userInfo: [String: Any]) {
         for handler in spezi.notificationHandler {
             handler.receiveRemoteNotification(userInfo)
         }
     }
 #elseif os(watchOS)
-    public func didReceiveRemoteNotification(_ userInfo: [AnyHashable: Any]) async -> WKBackgroundFetchResult {
+    open func didReceiveRemoteNotification(_ userInfo: [AnyHashable: Any]) async -> WKBackgroundFetchResult {
         await handleReceiveRemoteNotification(userInfo)
     }
 #endif


### PR DESCRIPTION
# Fix visibility of NotificationHandler default implementations and make Delegate methods open

## :recycle: Current situation & Problem
The `NotificationHandler` provides empty default implementations but their implementation are not marked public. Therefore, they have no effect. Secondly, some `SpeziAppDelegate` methods are not declared as open. This reduces flexibility in certain cases where it might be helpful to inject custom logic or even just to debug some issues.


## :gear: Release Notes 
* Fixed default implementation of the NotificationHandler.
* Make all `SpeziAppDelegate` methods open.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
