### PR TITLE
Minor concurrency adjustments

### DIFF
--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -166,7 +166,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate, Sendable {
 
         let result: Set<BackgroundFetchResult> = await withTaskGroup(of: BackgroundFetchResult.self) { @MainActor group in
             for handler in handlers {
-                group.addTask { @MainActor in
+                group.addTask { @Sendable @MainActor in
                     await handler.receiveRemoteNotification(userInfo)
                 }
             }

--- a/Sources/Spezi/Spezi/SpeziNotificationCenterDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziNotificationCenterDelegate.swift
@@ -29,7 +29,7 @@ class SpeziNotificationCenterDelegate: NSObject {
             }
 
             for handler in delegate.spezi.notificationHandler {
-                group.addTask { @MainActor in
+                group.addTask { @Sendable @MainActor in
                     await handler.handleNotificationAction(response)
                 }
             }


### PR DESCRIPTION
# Minor concurrency adjustments

## :recycle: Current situation & Problem
With Xcode Beta 5 there are new region-based concurrency checks that trigger a warning about strongly transferred parameters (see [SE-0414](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0414-region-based-isolation.md#using-transferring-to-simplify-nonisolated-actor-initializers-and-actor-deinitializers)) when passing actor isolated closures that is not explicitly marked as `@Sendable`. 
This PR resolves those warning by adding an explicit `@Sendable` annotation.

Interestingly the Swift Package Index marks Spezi 1.7.1 to be Swift 6 compatible even though they compile the project with Beta 5.

## :gear: Release Notes 
* Minor concurrency adjustments.


## :books: Documentation
--


## :white_check_mark: Testing
--

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
