### PR TITLE
Fix registerRemoteNotifications action would never return

### DIFF
--- a/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
@@ -103,17 +103,10 @@ public struct RegisterRemoteNotificationsAction: Sendable {
 
         try await registration.access.waitCheckingCancellation()
 
-        return try await withTaskCancellationHandler {
-            try Task.checkCancellation()
-            return try await withCheckedThrowingContinuation { continuation in
-                assert(registration.continuation == nil, "continuation wasn't nil")
-                registration.continuation = continuation
-                application.registerForRemoteNotifications()
-            }
-        } onCancel: {
-            Task { @MainActor in
-                registration.resume(with: .failure(CancellationError()))
-            }
+        return try await withCheckedThrowingContinuation { continuation in
+            assert(registration.continuation == nil, "continuation wasn't nil")
+            registration.continuation = continuation
+            application.registerForRemoteNotifications()
         }
     }
 }

--- a/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
@@ -76,7 +76,7 @@ public struct RegisterRemoteNotificationsAction {
 #if targetEnvironment(simulator)
     @available(*, unavailable,
         message: """
-                 Simulator devices cannot interact with APNS services. Please skip this call on simulator devices and test APNS registration \
+                 Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration \
                  on a real device.
                  Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/spezi/registerremotenotifications
                  """
@@ -131,7 +131,7 @@ extension Spezi {
     /// For more information refer to the [`registerForRemoteNotifications()`](https://developer.apple.com/documentation/uikit/uiapplication/1623078-registerforremotenotifications)
     /// documentation for `UIApplication` or for the respective equivalent for your current platform.
     ///
-    /// - Warning: Simulator devices cannot interact with APNS services. Please skip this call on simulator devices and test APNS registration on a real device.
+    /// - Important: Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration on a real device.
     ///
     /// Below is a short code example on how to use this action within your ``Module``.
     ///
@@ -162,7 +162,7 @@ extension Spezi {
 #if targetEnvironment(simulator)
     @available(*, unavailable,
                 message: """
-                 Simulator devices cannot interact with APNS services. Please skip this call on simulator devices and test APNS registration \
+                 Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration \
                  on a real device.
                  Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/spezi/registerremotenotifications
                  """

--- a/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
@@ -103,6 +103,12 @@ public struct RegisterRemoteNotificationsAction: Sendable {
 
         try await registration.access.waitCheckingCancellation()
 
+#if targetEnvironment(simulator)
+        async let _ = withTimeout(of: .seconds(10)) { @MainActor in
+            spezi.storage[RemoteNotificationContinuation.self]?.resume(with: .failure(TimeoutError()))
+        }
+#endif
+
         return try await withCheckedThrowingContinuation { continuation in
             assert(registration.continuation == nil, "continuation wasn't nil")
             registration.continuation = continuation

--- a/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/RegisterRemoteNotificationsAction.swift
@@ -104,7 +104,7 @@ public struct RegisterRemoteNotificationsAction: Sendable {
         try await registration.access.waitCheckingCancellation()
 
 #if targetEnvironment(simulator)
-        async let _ = withTimeout(of: .seconds(10)) { @MainActor in
+        async let _ = withTimeout(of: .seconds(5)) { @MainActor in
             spezi.storage[RemoteNotificationContinuation.self]?.resume(with: .failure(TimeoutError()))
         }
 #endif

--- a/Sources/Spezi/Capabilities/Notifications/UnregisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/UnregisterRemoteNotificationsAction.swift
@@ -14,6 +14,8 @@ import SwiftUI
 /// For more information refer to the [`unregisterForRemoteNotifications()`](https://developer.apple.com/documentation/uikit/uiapplication/1623093-unregisterforremotenotifications)
 /// documentation for `UIApplication` or for the respective equivalent for your current platform.
 ///
+/// - Important: Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration on a real device.
+///
 /// Below is a short code example on how to use this action within your ``Module``.
 ///
 /// ```swift
@@ -22,8 +24,10 @@ import SwiftUI
 ///     var unregisterRemoteNotifications
 ///
 ///     func onAccountLogout() {
+/// #if !targetEnvironment(simulator) // APNS interactions are unavailable on simulator devices
 ///         // handling your cleanup ...
 ///         unregisterRemoteNotifications()
+/// #endif
 ///     }
 /// }
 /// ```
@@ -32,8 +36,18 @@ public struct UnregisterRemoteNotificationsAction {
 
 
     /// Unregisters for all remote notifications received through Apple Push Notification service.
+#if targetEnvironment(simulator)
+    @available(*, unavailable,
+                message: """
+                 Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration \
+                 on a real device.
+                 Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/1.7.2/documentation/spezi/spezi/unregisterremotenotifications
+                 """
+    )
+#endif
     @MainActor
     public func callAsFunction() {
+#if !targetEnvironment(simulator)
 #if os(watchOS)
         let application = _Application.shared()
 #else
@@ -41,6 +55,9 @@ public struct UnregisterRemoteNotificationsAction {
 #endif
         
         application.unregisterForRemoteNotifications()
+#else
+        preconditionFailure("\(Self.self) is not available on simulator devices.")
+#endif
     }
 }
 
@@ -68,6 +85,15 @@ extension Spezi {
     /// ## Topics
     /// ### Action
     /// - ``UnregisterRemoteNotificationsAction``
+#if targetEnvironment(simulator)
+    @available(*, unavailable,
+                message: """
+                 Simulator devices cannot interact with APNS services. Please skip this call on simulator devices and test APNS registration \
+                 on a real device.
+                 Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/1.7.2/documentation/spezi/spezi/unregisterremotenotifications
+                 """
+    )
+#endif
     public var unregisterRemoteNotifications: UnregisterRemoteNotificationsAction {
         UnregisterRemoteNotificationsAction()
     }

--- a/Sources/Spezi/Capabilities/Notifications/UnregisterRemoteNotificationsAction.swift
+++ b/Sources/Spezi/Capabilities/Notifications/UnregisterRemoteNotificationsAction.swift
@@ -14,8 +14,6 @@ import SwiftUI
 /// For more information refer to the [`unregisterForRemoteNotifications()`](https://developer.apple.com/documentation/uikit/uiapplication/1623093-unregisterforremotenotifications)
 /// documentation for `UIApplication` or for the respective equivalent for your current platform.
 ///
-/// - Important: Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration on a real device.
-///
 /// Below is a short code example on how to use this action within your ``Module``.
 ///
 /// ```swift
@@ -24,30 +22,18 @@ import SwiftUI
 ///     var unregisterRemoteNotifications
 ///
 ///     func onAccountLogout() {
-/// #if !targetEnvironment(simulator) // APNS interactions are unavailable on simulator devices
 ///         // handling your cleanup ...
 ///         unregisterRemoteNotifications()
-/// #endif
 ///     }
 /// }
 /// ```
-public struct UnregisterRemoteNotificationsAction {
+public struct UnregisterRemoteNotificationsAction: Sendable {
     init() {}
 
 
     /// Unregisters for all remote notifications received through Apple Push Notification service.
-#if targetEnvironment(simulator)
-    @available(*, unavailable,
-                message: """
-                 Simulator devices cannot interact with APNS. Please skip this call on simulator devices and test APNS registration \
-                 on a real device.
-                 Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/1.7.2/documentation/spezi/spezi/unregisterremotenotifications
-                 """
-    )
-#endif
     @MainActor
     public func callAsFunction() {
-#if !targetEnvironment(simulator)
 #if os(watchOS)
         let application = _Application.shared()
 #else
@@ -55,9 +41,6 @@ public struct UnregisterRemoteNotificationsAction {
 #endif
         
         application.unregisterForRemoteNotifications()
-#else
-        preconditionFailure("\(Self.self) is not available on simulator devices.")
-#endif
     }
 }
 
@@ -85,15 +68,6 @@ extension Spezi {
     /// ## Topics
     /// ### Action
     /// - ``UnregisterRemoteNotificationsAction``
-#if targetEnvironment(simulator)
-    @available(*, unavailable,
-                message: """
-                 Simulator devices cannot interact with APNS services. Please skip this call on simulator devices and test APNS registration \
-                 on a real device.
-                 Refer to the Spezi documentation: https://swiftpackageindex.com/stanfordspezi/spezi/1.7.2/documentation/spezi/spezi/unregisterremotenotifications
-                 """
-    )
-#endif
     public var unregisterRemoteNotifications: UnregisterRemoteNotificationsAction {
         UnregisterRemoteNotificationsAction()
     }

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -79,9 +79,13 @@ import XCTRuntimeAssertions
 /// - ``launchOptions``
 /// - ``spezi``
 ///
-/// ### Actions
+/// ### Remote Notifications
 /// - ``registerRemoteNotifications``
 /// - ``unregisterRemoteNotifications``
+///
+/// ### Dynamically Loading Modules
+/// - ``loadModule(_:ownership:)``
+/// - ``unloadModule(_:)``
 @Observable
 public final class Spezi: Sendable {
     static let logger = Logger(subsystem: "edu.stanford.spezi", category: "Spezi")
@@ -93,7 +97,7 @@ public final class Spezi: Sendable {
     /// A shared repository to store any `KnowledgeSource`s restricted to the ``SpeziAnchor``.
     ///
     /// Every `Module` automatically conforms to `KnowledgeSource` and is stored within this storage object.
-    fileprivate(set) nonisolated(unsafe) var storage: SpeziStorage // nonisolated, writes are all isolated to @MainActor, just reads are non-isolated
+    nonisolated(unsafe) var storage: SpeziStorage // nonisolated, writes are all isolated to @MainActor, just reads are non-isolated
 
     /// Key is either a UUID for `@Modifier` or `@Model` property wrappers, or a `ModuleReference` for `EnvironmentAccessible` modifiers.
     @MainActor private var _viewModifiers: OrderedDictionary<AnyHashable, any ViewModifier> = [:]

--- a/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestsView.swift
+++ b/Tests/UITests/TestApp/LifecycleHandler/LifecycleHandlerTestsView.swift
@@ -14,7 +14,7 @@ import XCTSpezi
 struct LifecycleHandlerTestsView: View {
     @Environment(LifecycleHandlerModel.self)
     var model
-    
+
     
     var body: some View {
         VStack {

--- a/Tests/UITests/TestApp/RemoteNotifications/NotificationModule.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/NotificationModule.swift
@@ -1,0 +1,19 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+
+
+@MainActor
+class NotificationModule: Module, EnvironmentAccessible {
+    @Application(\.registerRemoteNotifications)
+    var registerRemoteNotifications
+
+    @Application(\.unregisterRemoteNotifications)
+    var unregisterRemoteNotifications
+}

--- a/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
@@ -40,6 +40,7 @@ struct RemoteNotificationsTestView: View {
                     }
                 }
                     .accessibilityElement(children: .combine)
+                    .accessibilityIdentifier("token-field")
             }
 
             Section("Actions") {

--- a/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
@@ -19,7 +19,7 @@ struct RemoteNotificationsTestView: View {
     @State private var task: Task<Void, Never>?
 
     var body: some View {
-        List {
+        List { // swiftlint:disable:this closure_body_length
             Section("Token") {
                 HStack {
                     Text(verbatim: "Token")

--- a/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
@@ -27,6 +27,10 @@ struct RemoteNotificationsTestView: View {
                     if let token {
                         Text(token.description)
                             .foregroundStyle(.green)
+                    } else if let error = error as? LocalizedError,
+                              let description = error.errorDescription ?? error.failureReason {
+                        Text(verbatim: description)
+                            .foregroundStyle(.red)
                     } else if error != nil {
                         Text(verbatim: "failed")
                             .foregroundStyle(.red)

--- a/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
@@ -1,0 +1,70 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct RemoteNotificationsTestView: View {
+    @Environment(NotificationModule.self)
+    private var notificationModule
+
+    @State private var token: Data?
+    @State private var error: Error?
+
+    @State private var task: Task<Void, Never>?
+
+    var body: some View {
+        List {
+            Section("Token") {
+                HStack {
+                    Text(verbatim: "Token")
+                    Spacer()
+                    if let token {
+                        Text(token.description)
+                            .foregroundStyle(.green)
+                    } else if error != nil {
+                        Text(verbatim: "failed")
+                            .foregroundStyle(.red)
+                    } else {
+                        Text(verbatim: "none")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                    .accessibilityElement(children: .combine)
+            }
+
+            Section("Actions") {
+                Button("Register") {
+                    task = Task { @MainActor in
+                        do {
+                            token = try await notificationModule.registerRemoteNotifications()
+                        } catch {
+                            self.error = error
+                        }
+                    }
+                }
+                Button("Unregister") {
+                    notificationModule.unregisterRemoteNotifications()
+                    token = nil
+                    error = nil
+                }
+            }
+        }
+            .onDisappear {
+                task?.cancel()
+            }
+    }
+}
+
+
+#if DEBUG
+#Preview {
+    RemoteNotificationsTestView()
+        .environment(NotificationModule())
+}
+#endif

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -19,6 +19,7 @@ class TestAppDelegate: SpeziAppDelegate {
             }
             ModuleWithModifier()
             ModuleWithModel()
+            NotificationModule()
         }
     }
 }

--- a/Tests/UITests/TestApp/SpeziTests.swift
+++ b/Tests/UITests/TestApp/SpeziTests.swift
@@ -14,7 +14,8 @@ enum SpeziTests: String, TestAppTests {
     case viewModifier = "ViewModifier"
     case lifecycleHandler = "LifecycleHandler"
     case model = "Model"
-    
+    case notifications = "Remote Notifications"
+
     
     func view(withNavigationPath path: Binding<NavigationPath>) -> some View {
         switch self {
@@ -24,6 +25,8 @@ enum SpeziTests: String, TestAppTests {
             LifecycleHandlerTestsView()
         case .model:
             ModelTestView()
+        case .notifications:
+            RemoteNotificationsTestView()
         }
     }
 }

--- a/Tests/UITests/TestApp/TestApp.entitlements
+++ b/Tests/UITests/TestApp/TestApp.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+	<key>com.apple.developer.aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Tests/UITests/TestApp/TestApp.entitlements.license
+++ b/Tests/UITests/TestApp/TestApp.entitlements.license
@@ -1,0 +1,5 @@
+This source file is part of the Stanford Spezi open-source project
+
+SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+
+SPDX-License-Identifier: MIT

--- a/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
+++ b/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
@@ -11,6 +11,11 @@ import XCTest
 
 final class RemoteNotificationsTests: XCTestCase {
     @MainActor
+    override func setUp() async throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
     func testRegistrationOnSimulator() throws {
         let app = XCUIApplication()
         app.launch()
@@ -26,7 +31,11 @@ final class RemoteNotificationsTests: XCTestCase {
         XCTAssertTrue(app.buttons["Unregister"].exists)
 
         app.buttons["Register"].tap()
-        XCTAssertTrue(app.staticTexts["Token, 80 bytes"].waitForExistence(timeout: 1.0))
+
+        if !app.staticTexts["Token, 80 bytes"].waitForExistence(timeout: 1.0) {
+            XCTAssertFalse(app.staticTexts["Token, failed"].exists)
+            XCTAssertTrue(app.staticTexts["Token, Timeout"].waitForExistence(timeout: 15))
+        }
 
         app.buttons["Unregister"].tap()
         XCTAssertTrue(app.staticTexts["Token, none"].waitForExistence(timeout: 1.0))

--- a/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
+++ b/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
@@ -1,0 +1,34 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+final class RemoteNotificationsTests: XCTestCase {
+    @MainActor
+    func testRegistrationOnSimulator() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+
+        XCTAssertTrue(app.buttons["Remote Notifications"].waitForExistence(timeout: 2.0))
+        app.buttons["Remote Notifications"].tap()
+
+        XCTAssertTrue(app.navigationBars["Remote Notifications"].waitForExistence(timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Token, none"].exists)
+        XCTAssertTrue(app.buttons["Register"].exists)
+        XCTAssertTrue(app.buttons["Unregister"].exists)
+
+        app.buttons["Register"].tap()
+        XCTAssertTrue(app.staticTexts["Token, 80 bytes"].waitForExistence(timeout: 1.0))
+
+        app.buttons["Unregister"].tap()
+        XCTAssertTrue(app.staticTexts["Token, none"].waitForExistence(timeout: 1.0))
+    }
+}

--- a/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
+++ b/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
@@ -32,9 +32,11 @@ final class RemoteNotificationsTests: XCTestCase {
 
         app.buttons["Register"].tap()
 
-        if !app.staticTexts["Token, 80 bytes"].waitForExistence(timeout: 1.0) {
+        if !(app.staticTexts["Token, 80 bytes"].waitForExistence(timeout: 1.0)
+             || app.staticTexts["Token, 60 bytes"].exists) {
             XCTAssertFalse(app.staticTexts["Token, failed"].exists)
-            XCTAssertTrue(app.staticTexts["Token, Timeout"].waitForExistence(timeout: 15))
+            XCTAssertTrue(app.staticTexts["Token, Timeout"].waitForExistence(timeout: 10))
+            print("The token registration timed out!")
         }
 
         app.buttons["Unregister"].tap()

--- a/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
+++ b/Tests/UITests/TestAppUITests/RemoteNotificationsTests.swift
@@ -36,8 +36,10 @@ final class RemoteNotificationsTests: XCTestCase {
              || app.staticTexts["Token, 60 bytes"].exists) {
             XCTAssertFalse(app.staticTexts["Token, failed"].exists)
             XCTAssertTrue(app.staticTexts["Token, Timeout"].waitForExistence(timeout: 10))
-            print("The token registration timed out!")
         }
+
+        // the unit test accepts both success and failure states. Therefore, print the content of the field to have it visible in the logs
+        print("Read token field as: \(app.staticTexts.matching(identifier: "token-field").firstMatch.debugDescription)")
 
         app.buttons["Unregister"].tap()
         XCTAssertTrue(app.staticTexts["Token, none"].waitForExistence(timeout: 1.0))

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -20,6 +20,7 @@
 		2FFDAD092A4AAEF400488F42 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */; };
 		2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */; };
 		2FFDAD0D2A4AB0CE00488F42 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FFDAD0C2A4AB0CE00488F42 /* XCTestExtensions */; };
+		A9AD5FF92C74860E00F3FBA8 /* RemoteNotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD5FF82C74860A00F3FBA8 /* RemoteNotificationsTests.swift */; };
 		A9F2ECD42AF0B85C0057C7DD /* ModuleWithModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2ECD32AF0B85C0057C7DD /* ModuleWithModifier.swift */; };
 		A9F2ECD62AF0BA500057C7DD /* ViewModifierTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2ECD52AF0BA500057C7DD /* ViewModifierTestView.swift */; };
 		A9F2ECD92AF198510057C7DD /* ModuleWithModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2ECD82AF198510057C7DD /* ModuleWithModel.swift */; };
@@ -53,12 +54,29 @@
 		2FFDAD062A4AAA2E00488F42 /* LifecycleHandlerTestModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTestModule.swift; sourceTree = "<group>"; };
 		2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTests.swift; sourceTree = "<group>"; };
+		A9AD5FF12C74827600F3FBA8 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
+		A9AD5FF82C74860A00F3FBA8 /* RemoteNotificationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsTests.swift; sourceTree = "<group>"; };
 		A9F2ECD32AF0B85C0057C7DD /* ModuleWithModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleWithModifier.swift; sourceTree = "<group>"; };
 		A9F2ECD52AF0BA500057C7DD /* ViewModifierTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModifierTestView.swift; sourceTree = "<group>"; };
 		A9F2ECD82AF198510057C7DD /* ModuleWithModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleWithModel.swift; sourceTree = "<group>"; };
 		A9F2ECDA2AF198590057C7DD /* ModelTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTestView.swift; sourceTree = "<group>"; };
 		A9F2ECDC2AF198690057C7DD /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		A9AD5FF52C7483B300F3FBA8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				NotificationModule.swift,
+				RemoteNotificationsTestView.swift,
+			);
+			target = 2F6D139128F5F384007C25D6 /* TestApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A9AD5FF42C7483AE00F3FBA8 /* RemoteNotifications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A9AD5FF52C7483B300F3FBA8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = RemoteNotifications; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2F6D138F28F5F384007C25D6 /* Frameworks */ = {
@@ -106,14 +124,16 @@
 		2F6D139428F5F384007C25D6 /* TestApp */ = {
 			isa = PBXGroup;
 			children = (
-				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				2F5FA4CD29E0A3BA0047A644 /* SpeziTests.swift */,
-				2FFDAD032A4AA99800488F42 /* LifecycleHandler */,
-				A9F2ECD72AF198330057C7DD /* ModelTests */,
-				2F9F07ED29090AF500CDC598 /* Shared */,
-				A9F2ECD22AF0B8460057C7DD /* ViewModifierTests */,
 				2F6D139928F5F386007C25D6 /* Assets.xcassets */,
 				2F01E8CE291493560089C46B /* Info.plist */,
+				2FFDAD032A4AA99800488F42 /* LifecycleHandler */,
+				A9F2ECD72AF198330057C7DD /* ModelTests */,
+				A9AD5FF42C7483AE00F3FBA8 /* RemoteNotifications */,
+				2F9F07ED29090AF500CDC598 /* Shared */,
+				2F5FA4CD29E0A3BA0047A644 /* SpeziTests.swift */,
+				A9AD5FF12C74827600F3FBA8 /* TestApp.entitlements */,
+				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
+				A9F2ECD22AF0B8460057C7DD /* ViewModifierTests */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -122,9 +142,10 @@
 			isa = PBXGroup;
 			children = (
 				2FB926E42974B0FC008E7B03 /* Info.plist */,
-				2F9F07F429090BA900CDC598 /* ViewModifierTests.swift */,
 				2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */,
 				A9F2ECDC2AF198690057C7DD /* ModelTests.swift */,
+				A9AD5FF82C74860A00F3FBA8 /* RemoteNotificationsTests.swift */,
+				2F9F07F429090BA900CDC598 /* ViewModifierTests.swift */,
 			);
 			path = TestAppUITests;
 			sourceTree = "<group>";
@@ -301,6 +322,7 @@
 			files = (
 				A9F2ECDD2AF198690057C7DD /* ModelTests.swift in Sources */,
 				2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */,
+				A9AD5FF92C74860E00F3FBA8 /* RemoteNotificationsTests.swift in Sources */,
 				2F9F07F529090BA900CDC598 /* ViewModifierTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -449,6 +471,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -485,6 +508,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = TestApp/TestApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
@@ -603,8 +627,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/XCTestExtensions";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 0.4.9;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		2F5FA4D029E0A4050047A644 /* XCTestApp in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5FA4CF29E0A4050047A644 /* XCTestApp */; };
 		2F5FA4D229E0B38C0047A644 /* XCTSpezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F5FA4D129E0B38C0047A644 /* XCTSpezi */; };
 		2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2F6D139928F5F386007C25D6 /* Assets.xcassets */; };
+		2F79AE292C7563C1005282F4 /* NotificationModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F79AE262C7563C1005282F4 /* NotificationModule.swift */; };
+		2F79AE2A2C7563C1005282F4 /* RemoteNotificationsTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F79AE272C7563C1005282F4 /* RemoteNotificationsTestView.swift */; };
 		2F9F07F129090B0500CDC598 /* TestAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07F029090B0500CDC598 /* TestAppDelegate.swift */; };
 		2F9F07F529090BA900CDC598 /* ViewModifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F9F07F429090BA900CDC598 /* ViewModifierTests.swift */; };
 		2FA7382C290ADFAA007ACEB9 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA7382B290ADFAA007ACEB9 /* TestApp.swift */; };
@@ -44,6 +46,8 @@
 		2F6D139228F5F384007C25D6 /* TestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2F6D139928F5F386007C25D6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2F6D13AC28F5F386007C25D6 /* TestAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TestAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2F79AE262C7563C1005282F4 /* NotificationModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationModule.swift; sourceTree = "<group>"; };
+		2F79AE272C7563C1005282F4 /* RemoteNotificationsTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsTestView.swift; sourceTree = "<group>"; };
 		2F7B6CB4294C03C800FDC494 /* TestApp.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = TestApp.xctestplan; path = UITests.xcodeproj/TestApp.xctestplan; sourceTree = "<group>"; };
 		2F9F07F029090B0500CDC598 /* TestAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestAppDelegate.swift; sourceTree = "<group>"; };
 		2F9F07F429090BA900CDC598 /* ViewModifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewModifierTests.swift; sourceTree = "<group>"; };
@@ -62,21 +66,6 @@
 		A9F2ECDA2AF198590057C7DD /* ModelTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTestView.swift; sourceTree = "<group>"; };
 		A9F2ECDC2AF198690057C7DD /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
-
-/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		A9AD5FF52C7483B300F3FBA8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				NotificationModule.swift,
-				RemoteNotificationsTestView.swift,
-			);
-			target = 2F6D139128F5F384007C25D6 /* TestApp */;
-		};
-/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
-
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		A9AD5FF42C7483AE00F3FBA8 /* RemoteNotifications */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A9AD5FF52C7483B300F3FBA8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = RemoteNotifications; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		2F6D138F28F5F384007C25D6 /* Frameworks */ = {
@@ -128,12 +117,12 @@
 				2F01E8CE291493560089C46B /* Info.plist */,
 				2FFDAD032A4AA99800488F42 /* LifecycleHandler */,
 				A9F2ECD72AF198330057C7DD /* ModelTests */,
-				A9AD5FF42C7483AE00F3FBA8 /* RemoteNotifications */,
+				2F79AE282C7563C1005282F4 /* RemoteNotifications */,
 				2F9F07ED29090AF500CDC598 /* Shared */,
+				A9F2ECD22AF0B8460057C7DD /* ViewModifierTests */,
 				2F5FA4CD29E0A3BA0047A644 /* SpeziTests.swift */,
 				A9AD5FF12C74827600F3FBA8 /* TestApp.entitlements */,
 				2FA7382B290ADFAA007ACEB9 /* TestApp.swift */,
-				A9F2ECD22AF0B8460057C7DD /* ViewModifierTests */,
 			);
 			path = TestApp;
 			sourceTree = "<group>";
@@ -155,6 +144,15 @@
 			children = (
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2F79AE282C7563C1005282F4 /* RemoteNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				2F79AE262C7563C1005282F4 /* NotificationModule.swift */,
+				2F79AE272C7563C1005282F4 /* RemoteNotificationsTestView.swift */,
+			);
+			path = RemoteNotifications;
 			sourceTree = "<group>";
 		};
 		2F9F07ED29090AF500CDC598 /* Shared */ = {
@@ -309,6 +307,8 @@
 				A9F2ECD62AF0BA500057C7DD /* ViewModifierTestView.swift in Sources */,
 				2F9F07F129090B0500CDC598 /* TestAppDelegate.swift in Sources */,
 				2FFDAD072A4AAA2E00488F42 /* LifecycleHandlerTestModule.swift in Sources */,
+				2F79AE292C7563C1005282F4 /* NotificationModule.swift in Sources */,
+				2F79AE2A2C7563C1005282F4 /* RemoteNotificationsTestView.swift in Sources */,
 				A9F2ECDB2AF198590057C7DD /* ModelTestView.swift in Sources */,
 				A9F2ECD42AF0B85C0057C7DD /* ModuleWithModifier.swift in Sources */,
 				2FFDAD052A4AA9D300488F42 /* LifecycleHandlerTestsView.swift in Sources */,


### PR DESCRIPTION
# Fix registerRemoteNotifications action would never return

## :recycle: Current situation & Problem
#98 introduced the `registerRemoteNotifications` action. However, the knowledge source that stores the continuation was never persisted in the store. Therefore, the continuation was never resumed and allocated resources forever.
This was fixed with this PR. We originally discussed supporting cancellation of the registration processed, however I decided against as it wasn't clear to properly handle cancellation (e.g., automatically call the unregister action? How to handle the delegate call that might arrive later. Especially when another call to the action might incur in the mean time).
This PR changes the behavior when concurrently calling the registerRemoteNotifications action. Now, the second caller will wait for the first call to complete instead of throwing a concurrence access error. This helps to share this resources with, e.g., multiple modules trying to retrieve an device token. 

**To emphasize: `registerRemoteNotifications` works on simulator devices!**

## :gear: Release Notes 
* Fixed an issue where the `registerRemoteNotifications` actions would never return.


## :books: Documentation
Slightly updated docs to provide more guidance around requesting authorization for notifications.


## :white_check_mark: Testing
Added a unit test that verifies that the action returns.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
