### PR TITLE
fix sporadic test failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
         .library(name: "XCTSpezi", targets: ["XCTSpezi"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", branch: "lukas/orderedarray-unsafe-operations"),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", branch: "lukas/fix"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.7"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,8 @@ let package = Package(
             dependencies: [
                 .target(name: "Spezi"),
                 .target(name: "SpeziTesting"),
-                .product(name: "RuntimeAssertionsTesting", package: "XCTRuntimeAssertions")
+                .product(name: "RuntimeAssertionsTesting", package: "XCTRuntimeAssertions"),
+                .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()

--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
         .library(name: "XCTSpezi", targets: ["XCTSpezi"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.1"),
-        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "1.1.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", branch: "lukas/orderedarray-unsafe-operations"),
+        .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", branch: "lukas/fix"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1")
     ] + swiftLintPackage(),
     targets: [
@@ -37,7 +37,7 @@ let package = Package(
             name: "Spezi",
             dependencies: [
                 .product(name: "SpeziFoundation", package: "SpeziFoundation"),
-                .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions"),
+                .product(name: "RuntimeAssertions", package: "XCTRuntimeAssertions"),
                 .product(name: "OrderedCollections", package: "swift-collections")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
@@ -65,7 +65,7 @@ let package = Package(
             dependencies: [
                 .target(name: "Spezi"),
                 .target(name: "SpeziTesting"),
-                .product(name: "XCTRuntimeAssertions", package: "XCTRuntimeAssertions")
+                .product(name: "RuntimeAssertionsTesting", package: "XCTRuntimeAssertions")
             ],
             swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()

--- a/Sources/Spezi/Capabilities/Communication/CollectPropertyWrapper.swift
+++ b/Sources/Spezi/Capabilities/Communication/CollectPropertyWrapper.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import RuntimeAssertions
 import SpeziFoundation
-import XCTRuntimeAssertions
 
 
 /// Refer to the documentation of ``Module/Collect``.

--- a/Sources/Spezi/Capabilities/Communication/ProvidePropertyWrapper.swift
+++ b/Sources/Spezi/Capabilities/Communication/ProvidePropertyWrapper.swift
@@ -8,8 +8,8 @@
 
 
 import Foundation
+import RuntimeAssertions
 import SpeziFoundation
-import XCTRuntimeAssertions
 
 
 /// A protocol that identifies a ``_ProvidePropertyWrapper`` which `Value` type is a `Collection`.

--- a/Sources/Spezi/Dependencies/DependencyManager.swift
+++ b/Sources/Spezi/Dependencies/DependencyManager.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import XCTRuntimeAssertions
+import RuntimeAssertions
 
 
 /// Gather information about modules with dependencies.

--- a/Sources/Spezi/Dependencies/Property/DependencyContext.swift
+++ b/Sources/Spezi/Dependencies/Property/DependencyContext.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import XCTRuntimeAssertions
+import RuntimeAssertions
 
 
 protocol AnyDependencyContext: DependencyDeclaration {

--- a/Sources/Spezi/Dependencies/Property/DependencyPropertyWrapper.swift
+++ b/Sources/Spezi/Dependencies/Property/DependencyPropertyWrapper.swift
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+import RuntimeAssertions
 import SpeziFoundation
-import XCTRuntimeAssertions
 
 
 /// A `@Dependency` for a single, typed ``Module``.

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -7,8 +7,8 @@
 //
 
 import Foundation
+import RuntimeAssertions
 import SwiftUI
-import XCTRuntimeAssertions
 
 
 #if os(iOS) || os(visionOS) || os(tvOS)

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -9,9 +9,9 @@
 
 import OrderedCollections
 import OSLog
+import RuntimeAssertions
 import SpeziFoundation
 import SwiftUI
-import XCTRuntimeAssertions
 
 
 /// Open-source framework for rapid development of modern, interoperable digital health applications.

--- a/Sources/Spezi/Standard/StandardPropertyWrapper.swift
+++ b/Sources/Spezi/Standard/StandardPropertyWrapper.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import XCTRuntimeAssertions
+import RuntimeAssertions
 
 
 /// Refer to ``Module/StandardActor`` for information on how to use the `@StandardActor` property wrapper. Do not use the `_StandardPropertyWrapper` directly.

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -140,7 +140,7 @@ struct NotificationsTests {
 
         async let registration = action()
 
-        try await Task.sleep(for: .milliseconds(100)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
 #if os(iOS) || os(visionOS) || os(tvOS)
         delegate.application(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
@@ -150,7 +150,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
 #endif
 
-        try await Task.sleep(for: .milliseconds(100)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
         do {
             _ = try await registration

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -140,7 +140,7 @@ struct NotificationsTests {
 
         async let registration = action()
 
-        try await Task.sleep(for: .milliseconds(50)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(100)) // allow dispatch of Task above
 
 #if os(iOS) || os(visionOS) || os(tvOS)
         delegate.application(UIApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
@@ -150,7 +150,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didFailToRegisterForRemoteNotificationsWithError: TestError.testError)
 #endif
 
-        try await Task.sleep(for: .milliseconds(50)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(100)) // allow dispatch of Task above
 
         do {
             _ = try await registration

--- a/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/NotificationsTests.swift
@@ -106,7 +106,7 @@ struct NotificationsTests {
         let action = module.registerRemoteNotifications
 
         async let registration = action()
-        try await Task.sleep(for: .milliseconds(50)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
         let data = try #require("Hello World".data(using: .utf8))
 
@@ -118,7 +118,7 @@ struct NotificationsTests {
         delegate.application(NSApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: data)
 #endif
 
-        try await Task.sleep(for: .milliseconds(50)) // allow dispatch of Task above
+        try await Task.sleep(for: .milliseconds(250)) // allow dispatch of Task above
 
         _ = try await registration
         #expect(module.lastDeviceToken == data)

--- a/Tests/SpeziTests/DependenciesTests/DependencyBuilderTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyBuilderTests.swift
@@ -7,8 +7,7 @@
 //
 
 import Spezi
-import XCTest
-import XCTRuntimeAssertions
+import Testing
 
 private protocol ExampleTypeConstraint: Module {}
 
@@ -31,40 +30,41 @@ class ExampleDependencyModule: Module {
     }
 }
 
-
-final class DependencyBuilderTests: XCTestCase {
+@Suite
+struct DependencyBuilderTests {
+    @Test
     @MainActor
-    func testDependencyCollection() {
+    func dependencyCollection() {
         var collection = DependencyCollection(ExampleDependentModule())
-        XCTAssertEqual(collection.count, 1)
-        XCTAssertFalse(collection.isEmpty)
-
+        #expect(collection.count == 1)
+        #expect(!collection.isEmpty)
         collection.append(ExampleDependentModule())
-
-        XCTAssertEqual(collection.count, 2)
+        #expect(collection.count == 2)
     }
 
+    
+    @Test
     @available(*, deprecated, message: "Propagate deprecation warning.")
     @MainActor
-    func testDeprecatedInits() {
+    func deprecatedInits() {
         let collection1 = DependencyCollection(singleEntry: ExampleDependentModule())
         let collection2 = DependencyCollection(singleEntry: {
             ExampleDependentModule()
         })
-
-        XCTAssertEqual(collection1.count, 1)
-        XCTAssertEqual(collection2.count, 1)
+        #expect(collection1.count == 1)
+        #expect(collection2.count == 1)
     }
 
 
+    @Test
     @MainActor
-    func testDependencyBuilder() throws {
+    func dependencyBuilder() throws {
         let module = ExampleDependencyModule {
             ExampleDependentModule()
         }
         let initializedModules = DependencyManager.resolveWithoutErrors([module])
-        XCTAssertEqual(initializedModules.count, 2)
-        _ = try XCTUnwrap(initializedModules[0] as? ExampleDependentModule)
-        _ = try XCTUnwrap(initializedModules[1] as? ExampleDependencyModule)
+        #expect(initializedModules.count == 2)
+        _ = try #require(initializedModules[0] as? ExampleDependentModule)
+        _ = try #require(initializedModules[1] as? ExampleDependencyModule)
     }
 }

--- a/Tests/SpeziTests/DependenciesTests/DependencyContextTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyContextTests.swift
@@ -6,25 +6,27 @@
 // SPDX-License-Identifier: MIT
 //
 
+import RuntimeAssertionsTesting
 import Spezi
-import XCTest
-import XCTRuntimeAssertions
+import Testing
 
 private final class ExampleModule: Module {}
 
-final class DependencyContextTests: XCTestCase {
-    func testInjectionPreconditionDependencyPropertyWrapper() throws {
-        try XCTRuntimePrecondition {
+@Suite
+struct DependencyContextTests {
+    @Test
+    func injectionPreconditionDependencyPropertyWrapper() throws {
+        expectRuntimePrecondition {
             _ = _DependencyPropertyWrapper<TestModule>(wrappedValue: TestModule(), TestModule.self).wrappedValue
         }
     }
     
-    func testInjectionPreconditionDynamicDependenciesPropertyWrapper() throws {
-        try XCTRuntimePrecondition {
+    @Test
+    func injectionPreconditionDynamicDependenciesPropertyWrapper() throws {
+        expectRuntimePrecondition {
             _ = _DependencyPropertyWrapper {
                 ExampleModule()
-            }
-                .wrappedValue
+            }.wrappedValue
         }
     }
 }

--- a/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
@@ -352,7 +352,7 @@ final class DependencyTests: XCTestCase { // swiftlint:disable:this type_body_le
         let spezi = try runModuleTests(deinitExpectation: deinitExpectation)
         _ = spezi
 
-        try await Task.sleep(for: .milliseconds(50)) // deinit need to get back to MainActor
+        try await Task.sleep(for: .milliseconds(250)) // deinit need to get back to MainActor
 
         XCTAssertEqual(spezi.modules.count, 5)
 

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -8,7 +8,6 @@
 
 @testable @_spi(Spezi) import Spezi
 import XCTest
-import XCTRuntimeAssertions
 
 
 final class ModuleBuilderTests: XCTestCase {

--- a/Tests/SpeziTests/StandardTests/StandardUnfulfilledConstraintTests.swift
+++ b/Tests/SpeziTests/StandardTests/StandardUnfulfilledConstraintTests.swift
@@ -8,8 +8,7 @@
 
 @testable import Spezi
 import SwiftUI
-import XCTest
-import XCTRuntimeAssertions
+import Testing
 
 
 private protocol UnfulfilledExampleConstraint: Standard {
@@ -17,10 +16,9 @@ private protocol UnfulfilledExampleConstraint: Standard {
 }
 
 
-final class StandardUnfulfilledConstraintTests: XCTestCase {
+struct StandardUnfulfilledConstraintTests {
     final class StandardUCTestModule: Module {
         @StandardActor private var standard: any UnfulfilledExampleConstraint
-        
         
         func configure() {
             Task {
@@ -29,21 +27,23 @@ final class StandardUnfulfilledConstraintTests: XCTestCase {
         }
     }
     
-
+    @Test
     @MainActor
-    func testStandardUnfulfilledConstraint() throws {
+    func standardUnfulfilledConstraint() throws {
         let configuration = Configuration(standard: MockStandard()) {}
         let spezi = Spezi(from: configuration)
-
-        XCTAssertThrowsError(try spezi.loadModules([StandardUCTestModule()], ownership: .spezi)) { error in
+        #expect {
+            try spezi.loadModules([StandardUCTestModule()], ownership: .spezi)
+        } throws: { error in
             guard let moduleError = error as? SpeziModuleError,
                   case let .property(propertyError) = moduleError,
                   case let .unsatisfiedStandardConstraint(constraint, standard) = propertyError else {
-                XCTFail("Encountered unexpected error: \(error)")
-                return
+                Issue.record("Encountered unexpected error: \(error)")
+                return false
             }
-            XCTAssertEqual(constraint, "UnfulfilledExampleConstraint")
-            XCTAssertEqual(standard, "MockStandard")
+            #expect(constraint == "UnfulfilledExampleConstraint")
+            #expect(standard == "MockStandard")
+            return true
         }
     }
 }


### PR DESCRIPTION
# fix sporadic test failures

## :recycle: Current situation & Problem
#122 lowered a wait in a test from 0.5 sec to 0.05 sec, which caused a `UIApplicationDelegate.application(_:didFailToRegisterForRemoteNotificationsWithError:)` call to sometimes not get dispatched in time, leading to the test failing.
this PR increases the wait duration to 0.25 sec, which hopefully will be enough to make it work properly


## :gear: Release Notes
n/a


## :books: Documentation
n/a


## :white_check_mark: Testing
tests should now run more reliably again

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
