### PR TITLE
Support Structured Concurrency at the Module level

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,5 +13,5 @@ Spezi contributors
 
 * [Paul Schmiedmayer](https://github.com/PSchmiedmayer)
 * [Vishnu Ravi](https://github.com/vishnuravi)
-* [Andreas Bauer](https://github.com/Supereg)
+* [Andreas Bauer](https://github.com/bauer-andreas)
 * [Philipp Zagar](https://github.com/philippzagar)

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .library(name: "XCTSpezi", targets: ["XCTSpezi"])
     ],
     dependencies: [
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.7"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.8"),
         .package(url: "https://github.com/StanfordBDHG/XCTRuntimeAssertions.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.1")
     ] + swiftLintPackage(),

--- a/Sources/Spezi/Capabilities/ApplicationPropertyWrapper.swift
+++ b/Sources/Spezi/Capabilities/ApplicationPropertyWrapper.swift
@@ -46,13 +46,14 @@ extension _ApplicationPropertyWrapper: SpeziPropertyWrapper {
     func inject(spezi: Spezi) {
         state.spezi = spezi
         if spezi.createsCopy(keyPath) {
+            // TODO: store more things as a shadow copy?
             state.shadowCopy = spezi[keyPath: keyPath]
         }
     }
 
     func clear() {
         state.spezi = nil
-        state.shadowCopy = nil
+        // we do not clear the shadow copy to make sure the property wrapper stays accessible in cleanup scenarios
     }
 }
 

--- a/Sources/Spezi/Capabilities/ApplicationPropertyWrapper.swift
+++ b/Sources/Spezi/Capabilities/ApplicationPropertyWrapper.swift
@@ -46,7 +46,6 @@ extension _ApplicationPropertyWrapper: SpeziPropertyWrapper {
     func inject(spezi: Spezi) {
         state.spezi = spezi
         if spezi.createsCopy(keyPath) {
-            // TODO: store more things as a shadow copy?
             state.shadowCopy = spezi[keyPath: keyPath]
         }
     }

--- a/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
+++ b/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
@@ -20,4 +20,3 @@ extension ServiceModule {
         ObjectIdentifier(self)
     }
 }
-

--- a/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
+++ b/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
@@ -1,13 +1,16 @@
 //
-//  ServiceModule.swift
-//  Spezi
+// This source file is part of the Stanford XCTestExtensions open-source project
 //
-//  Created by Andreas Bauer on 03.06.25.
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
 //
-
+// SPDX-License-Identifier: MIT
+//
 
 /// A Module that hooks into the structured concurrency service lifecycle of the application.
 public protocol ServiceModule: Module, Sendable {
+    /// Runs the service module.
+    ///
+    /// This task is executed as a child task of the SwiftUI App lifecycle. The task is cancelled once the app is about to terminate.
     func run() async
 }
 
@@ -17,3 +20,4 @@ extension ServiceModule {
         ObjectIdentifier(self)
     }
 }
+

--- a/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
+++ b/Sources/Spezi/Capabilities/Lifecycle/ServiceModule.swift
@@ -1,0 +1,19 @@
+//
+//  ServiceModule.swift
+//  Spezi
+//
+//  Created by Andreas Bauer on 03.06.25.
+//
+
+
+/// A Module that hooks into the structured concurrency service lifecycle of the application.
+public protocol ServiceModule: Module, Sendable {
+    func run() async
+}
+
+
+extension ServiceModule {
+    var moduleId: ObjectIdentifier {
+        ObjectIdentifier(self)
+    }
+}

--- a/Sources/Spezi/Module/Module.swift
+++ b/Sources/Spezi/Module/Module.swift
@@ -7,12 +7,6 @@
 //
 
 
-/// A Module that hooks into the structured concurrency service lifecycle of the application.
-public protocol ServiceModule: Module, Sendable {
-    func run() async throws(CancellationError) // TODO: can it throw a general error?
-}
-
-
 // note: detailed documentation is provided as an article extension in the DocC bundle
 /// A `Module` defines a software subsystem that can be configured as part of the ``SpeziAppDelegate/configuration``.
 public protocol Module: AnyObject {

--- a/Sources/Spezi/Module/Module.swift
+++ b/Sources/Spezi/Module/Module.swift
@@ -7,6 +7,12 @@
 //
 
 
+/// A Module that hooks into the structured concurrency service lifecycle of the application.
+public protocol ServiceModule: Module, Sendable {
+    func run() async throws(CancellationError) // TODO: can it throw a general error?
+}
+
+
 // note: detailed documentation is provided as an article extension in the DocC bundle
 /// A `Module` defines a software subsystem that can be configured as part of the ``SpeziAppDelegate/configuration``.
 public protocol Module: AnyObject {

--- a/Sources/Spezi/Spezi.docc/Module/Module.md
+++ b/Sources/Spezi/Spezi.docc/Module/Module.md
@@ -18,6 +18,9 @@ A `Module` is placed into the ``Configuration`` section of your App to enable an
 The ``Module/configure()-5pa83`` method is called on the initialization of the Spezi instance to perform a lightweight configuration of the module.
 It is advised that longer setup tasks are done in an asynchronous task and started during the call of the configure method.
 
+> Tip: Conform to the ``ServiceModule`` protocol and implement the ``ServiceModule/run()`` method to participate in the structure concurrency
+    lifecycle of the SwiftUI app.
+
 ### Module Constraints
 
 A ``Standard`` is the key module that orchestrates the data flow within the application and is provided upon App configuration.
@@ -61,6 +64,10 @@ class ExampleModule: Module {
 ### Configuration
 
 - ``configure()-5pa83``
+
+### Structured Concurrency
+
+- ``ServiceModule``
 
 ### Capabilities
 - <doc:Interactions-with-SwiftUI>

--- a/Sources/Spezi/Spezi/ServiceModuleGroup.swift
+++ b/Sources/Spezi/Spezi/ServiceModuleGroup.swift
@@ -1,5 +1,14 @@
+//
+// This source file is part of the Stanford XCTestExtensions open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
 import OSLog
 import SpeziFoundation
+
 
 struct ServiceModuleGroup {
     private enum Input {

--- a/Sources/Spezi/Spezi/ServiceModuleGroup.swift
+++ b/Sources/Spezi/Spezi/ServiceModuleGroup.swift
@@ -1,0 +1,49 @@
+import SpeziFoundation
+
+struct ServiceModuleGroup {
+    private enum Input {
+        case run(any ServiceModule) // TODO: support unloading?
+        case cancel(any ServiceModule)
+    }
+
+    private let input: (stream: AsyncStream<Input>, continuation: AsyncStream<Input>.Continuation)
+
+    init() {
+        self.input = AsyncStream.makeStream()
+    }
+
+    func run(service: some ServiceModule) {
+        input.continuation.yield(.run(service))
+    }
+
+    func cancel(service: some ServiceModule) {
+        input.continuation.yield(.cancel(service)) // TODO: allow to await the cancellation somehow?
+    }
+
+    nonisolated func run() async {
+        let stream = input.stream
+        await withDiscardingTaskGroup { group in
+            var taskHandles: [ObjectIdentifier: CancelableTaskHandle] = [:]
+
+            // TODO: keep track of tasks with cancellable child tasks?
+            for await input in stream {
+                switch input {
+                case let .run(module):
+                    guard taskHandles[module.moduleId] == nil else {
+                        continue // TODO: log that, how to handle? just replace it?
+                    }
+
+                    let handle = group.addCancelableTask {
+                        // TODO: make the task cancellable, some of the dependency un-injection must be moved to when the module finished unloading?
+                        await module.run()
+                    }
+
+                    taskHandles[module.moduleId] = handle
+                case let .cancel(module):
+                    let handle = taskHandles.removeValue(forKey: module.moduleId)
+                    handle?.cancel()
+                }
+            }
+        }
+    }
+}

--- a/Sources/Spezi/Spezi/Spezi+Preview.swift
+++ b/Sources/Spezi/Spezi/Spezi+Preview.swift
@@ -84,6 +84,7 @@ extension View {
         let spezi = Spezi(standard: standard, modules: modules().elements, storage: storage)
 
         return modifier(SpeziViewModifier(spezi))
+            .task(spezi.run)
 #if os(iOS) || os(visionOS) || os(tvOS)
             .task { @MainActor in
                 if case let .launchWithOptions(options) = simulateLifecycle {

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -199,9 +199,7 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     
     /// Run the Spezi service lifecycle.
     func run() async {
-        logger.debug("Starting the Spezi Service.")
         await serviceGroup.run()
-        logger.debug("Shutting down Spezi.")
     }
 
     /// Load a new Module.

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -22,6 +22,7 @@ struct SpeziViewModifier: ViewModifier {
     func body(content: Content) -> some View {
         spezi.viewModifiers
             .modify(content)
+            .task(spezi.run) // service lifecycle
     }
 }
 

--- a/Tests/UITests/TestApp/ModelTests/ModuleWithService.swift
+++ b/Tests/UITests/TestApp/ModelTests/ModuleWithService.swift
@@ -21,9 +21,11 @@ struct ModuleWithServiceView: View {
 
 
 @Observable
+@MainActor
 final class ModuleWithService: ServiceModule, EnvironmentAccessible {
-    enum State: CustomStringConvertible {
+    enum State: String, CustomStringConvertible {
         case uninitialized
+        case configured
         case loaded
         case finished
 
@@ -31,6 +33,8 @@ final class ModuleWithService: ServiceModule, EnvironmentAccessible {
             switch self {
             case .uninitialized:
                 "Module is not running."
+            case .configured:
+                "Module is configured."
             case .loaded:
                 "Module is running."
             case .finished:
@@ -39,15 +43,18 @@ final class ModuleWithService: ServiceModule, EnvironmentAccessible {
         }
     }
 
-    @MainActor var state: State = .uninitialized
+    var state: State = .uninitialized
 
     nonisolated init() {}
 
-    @MainActor
+    func configure() {
+        state = .configured
+    }
+
     func run() async {
         let input = AsyncStream<Void>.makeStream()
 
-        if state == .uninitialized {
+        if state == .configured {
             state = .loaded
         }
 

--- a/Tests/UITests/TestApp/ModelTests/ModuleWithService.swift
+++ b/Tests/UITests/TestApp/ModelTests/ModuleWithService.swift
@@ -1,0 +1,58 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Spezi
+import SwiftUI
+
+
+struct ModuleWithServiceView: View {
+    @Environment(ModuleWithService.self)
+    private var module
+
+    var body: some View {
+        Text(module.state.description)
+    }
+}
+
+
+@Observable
+final class ModuleWithService: ServiceModule, EnvironmentAccessible {
+    enum State: CustomStringConvertible {
+        case uninitialized
+        case loaded
+        case finished
+
+        var description: String {
+            switch self {
+            case .uninitialized:
+                "Module is not running."
+            case .loaded:
+                "Module is running."
+            case .finished:
+                "Module completed!"
+            }
+        }
+    }
+
+    @MainActor var state: State = .uninitialized
+
+    nonisolated init() {}
+
+    @MainActor
+    func run() async {
+        let input = AsyncStream<Void>.makeStream()
+
+        if state == .uninitialized {
+            state = .loaded
+        }
+
+        for await _ in input.stream {}
+
+        state = .finished
+    }
+}

--- a/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
+++ b/Tests/UITests/TestApp/Shared/TestAppDelegate.swift
@@ -19,6 +19,7 @@ class TestAppDelegate: SpeziAppDelegate {
             ModuleWithModifier()
             ModuleWithModel()
             NotificationModule()
+            ModuleWithService()
         }
     }
 }

--- a/Tests/UITests/TestApp/TestApp.swift
+++ b/Tests/UITests/TestApp/TestApp.swift
@@ -15,10 +15,14 @@ import XCTestApp
 struct UITestsApp: App {
     @ApplicationDelegateAdaptor(TestAppDelegate.self) var appDelegate
 
-    
     var body: some Scene {
         WindowGroup {
             TestAppTestsView<SpeziTests>()
+                .toolbar {
+                    ToolbarItem(placement: .bottomBar) {
+                        ModuleWithServiceView()
+                    }
+                }
                 .spezi(appDelegate)
         }
     }

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -54,4 +54,41 @@ final class LifecycleHandlerTests: XCTestCase {
         XCTAssert(app.staticTexts["SceneDidEnterBackground: 1"].exists)
         XCTAssert(app.staticTexts["ApplicationWillTerminate: 0"].exists)
     }
+
+    @MainActor
+    func testServiceModule() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--lifecycleTests"]
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+
+        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+
+        let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
+#if os(visionOS)
+        springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
+#else
+        springboard.activate()
+#endif
+
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+
+        app.activate()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+
+#if os(visionOS)
+        springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
+#else
+        springboard.activate()
+#endif
+        XCTAssertTrue(springboard.wait(for: .runningForeground, timeout: 2.0))
+
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
+        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+    }
 }

--- a/Tests/UITests/UITests.xcodeproj/project.pbxproj
+++ b/Tests/UITests/UITests.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 90;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -22,6 +22,7 @@
 		2FFDAD092A4AAEF400488F42 /* FeatureFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */; };
 		2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */; };
 		2FFDAD0D2A4AB0CE00488F42 /* XCTestExtensions in Frameworks */ = {isa = PBXBuildFile; productRef = 2FFDAD0C2A4AB0CE00488F42 /* XCTestExtensions */; };
+		A99774CE2DEF871A0080AB29 /* ModuleWithService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99774CD2DEF87150080AB29 /* ModuleWithService.swift */; };
 		A9AD5FF92C74860E00F3FBA8 /* RemoteNotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AD5FF82C74860A00F3FBA8 /* RemoteNotificationsTests.swift */; };
 		A9F2ECD42AF0B85C0057C7DD /* ModuleWithModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2ECD32AF0B85C0057C7DD /* ModuleWithModifier.swift */; };
 		A9F2ECD62AF0BA500057C7DD /* ViewModifierTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F2ECD52AF0BA500057C7DD /* ViewModifierTestView.swift */; };
@@ -58,6 +59,7 @@
 		2FFDAD062A4AAA2E00488F42 /* LifecycleHandlerTestModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTestModule.swift; sourceTree = "<group>"; };
 		2FFDAD082A4AAEF400488F42 /* FeatureFlags.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlags.swift; sourceTree = "<group>"; };
 		2FFDAD0A2A4AAF3600488F42 /* LifecycleHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LifecycleHandlerTests.swift; sourceTree = "<group>"; };
+		A99774CD2DEF87150080AB29 /* ModuleWithService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleWithService.swift; sourceTree = "<group>"; };
 		A9AD5FF12C74827600F3FBA8 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
 		A9AD5FF82C74860A00F3FBA8 /* RemoteNotificationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsTests.swift; sourceTree = "<group>"; };
 		A9F2ECD32AF0B85C0057C7DD /* ModuleWithModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleWithModifier.swift; sourceTree = "<group>"; };
@@ -70,21 +72,17 @@
 /* Begin PBXFrameworksBuildPhase section */
 		2F6D138F28F5F384007C25D6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2F5FA4D229E0B38C0047A644 /* XCTSpezi in Frameworks */,
 				2F5FA4CC29E0A2F40047A644 /* Spezi in Frameworks */,
 				2F5FA4D029E0A4050047A644 /* XCTestApp in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2F6D13A928F5F386007C25D6 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2FFDAD0D2A4AB0CE00488F42 /* XCTestExtensions in Frameworks */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
@@ -185,6 +183,7 @@
 		A9F2ECD72AF198330057C7DD /* ModelTests */ = {
 			isa = PBXGroup;
 			children = (
+				A99774CD2DEF87150080AB29 /* ModuleWithService.swift */,
 				A9F2ECD82AF198510057C7DD /* ModuleWithModel.swift */,
 				A9F2ECDA2AF198590057C7DD /* ModelTestView.swift */,
 			);
@@ -203,8 +202,6 @@
 				2F6D139028F5F384007C25D6 /* Resources */,
 			);
 			buildRules = (
-			);
-			dependencies = (
 			);
 			name = TestApp;
 			packageProductDependencies = (
@@ -245,7 +242,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1600;
+				LastUpgradeCheck = 1640;
 				TargetAttributes = {
 					2F6D139128F5F384007C25D6 = {
 						CreatedOnToolsVersion = 14.1;
@@ -267,7 +264,7 @@
 			packageReferences = (
 				2F746D9D29962B2A00BF54FE /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
 			);
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 90;
 			productRefGroup = 2F6D139328F5F384007C25D6 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -281,25 +278,20 @@
 /* Begin PBXResourcesBuildPhase section */
 		2F6D139028F5F384007C25D6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2F6D139A28F5F386007C25D6 /* Assets.xcassets in Resources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2F6D13AA28F5F386007C25D6 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2F6D138E28F5F384007C25D6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				2F5FA4CE29E0A3BA0047A644 /* SpeziTests.swift in Sources */,
 				2FFDAD092A4AAEF400488F42 /* FeatureFlags.swift in Sources */,
@@ -311,21 +303,19 @@
 				2F79AE2A2C7563C1005282F4 /* RemoteNotificationsTestView.swift in Sources */,
 				A9F2ECDB2AF198590057C7DD /* ModelTestView.swift in Sources */,
 				A9F2ECD42AF0B85C0057C7DD /* ModuleWithModifier.swift in Sources */,
+				A99774CE2DEF871A0080AB29 /* ModuleWithService.swift in Sources */,
 				2FFDAD052A4AA9D300488F42 /* LifecycleHandlerTestsView.swift in Sources */,
 				A9F2ECD92AF198510057C7DD /* ModuleWithModel.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 		2F6D13A828F5F386007C25D6 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
 			files = (
 				A9F2ECDD2AF198690057C7DD /* ModelTests.swift in Sources */,
 				2FFDAD0B2A4AAF3700488F42 /* LifecycleHandlerTests.swift in Sources */,
 				A9AD5FF92C74860E00F3FBA8 /* RemoteNotificationsTests.swift in Sources */,
 				2F9F07F529090BA900CDC598 /* ViewModifierTests.swift in Sources */,
 			);
-			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
@@ -338,7 +328,7 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		2F6D13B428F5F386007C25D6 /* Debug */ = {
+		2F6D13B428F5F386007C25D6 /* Debug configuration for PBXProject "UITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -373,6 +363,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
@@ -406,7 +397,7 @@
 			};
 			name = Debug;
 		};
-		2F6D13B528F5F386007C25D6 /* Release */ = {
+		2F6D13B528F5F386007C25D6 /* Release configuration for PBXProject "UITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -441,6 +432,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
@@ -468,7 +460,7 @@
 			};
 			name = Release;
 		};
-		2F6D13B728F5F386007C25D6 /* Debug */ = {
+		2F6D13B728F5F386007C25D6 /* Debug configuration for PBXNativeTarget "TestApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -477,7 +469,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
@@ -505,7 +496,7 @@
 			};
 			name = Debug;
 		};
-		2F6D13B828F5F386007C25D6 /* Release */ = {
+		2F6D13B828F5F386007C25D6 /* Release configuration for PBXNativeTarget "TestApp" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -514,7 +505,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestApp/Info.plist;
@@ -542,12 +532,11 @@
 			};
 			name = Release;
 		};
-		2F6D13BD28F5F386007C25D6 /* Debug */ = {
+		2F6D13BD28F5F386007C25D6 /* Debug configuration for PBXNativeTarget "TestAppUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestAppUITests/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -566,12 +555,11 @@
 			};
 			name = Debug;
 		};
-		2F6D13BE28F5F386007C25D6 /* Release */ = {
+		2F6D13BE28F5F386007C25D6 /* Release configuration for PBXNativeTarget "TestAppUITests" */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 637867499T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = TestAppUITests/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -596,28 +584,25 @@
 		2F6D138D28F5F384007C25D6 /* Build configuration list for PBXProject "UITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2F6D13B428F5F386007C25D6 /* Debug */,
-				2F6D13B528F5F386007C25D6 /* Release */,
+				2F6D13B428F5F386007C25D6 /* Debug configuration for PBXProject "UITests" */,
+				2F6D13B528F5F386007C25D6 /* Release configuration for PBXProject "UITests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		2F6D13B628F5F386007C25D6 /* Build configuration list for PBXNativeTarget "TestApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2F6D13B728F5F386007C25D6 /* Debug */,
-				2F6D13B828F5F386007C25D6 /* Release */,
+				2F6D13B728F5F386007C25D6 /* Debug configuration for PBXNativeTarget "TestApp" */,
+				2F6D13B828F5F386007C25D6 /* Release configuration for PBXNativeTarget "TestApp" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 		2F6D13BC28F5F386007C25D6 /* Build configuration list for PBXNativeTarget "TestAppUITests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2F6D13BD28F5F386007C25D6 /* Debug */,
-				2F6D13BE28F5F386007C25D6 /* Release */,
+				2F6D13BD28F5F386007C25D6 /* Debug configuration for PBXNativeTarget "TestAppUITests" */,
+				2F6D13BE28F5F386007C25D6 /* Release configuration for PBXNativeTarget "TestAppUITests" */,
 			);
-			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */

--- a/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
+++ b/Tests/UITests/UITests.xcodeproj/xcshareddata/xcschemes/TestApp.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1600"
+   LastUpgradeVersion = "1640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
# Support Structured Concurrency at the Module level

## :recycle: Current situation & Problem
Currently, it is hard for `Module`s to use async/await features without breaking structured concurrency and needing to spawn an unstructured task. Spawning unstructured task is strongly discouraged, as usually people fail to manage priorities and priority escalation and cooperative task cancellation. They may introduce resource leaks, unpredictable execution order or subtle concurrency bugs.
This PR adds the ability for a `Module` to conform to the `ServiceModule` to participate in the structured concurrency lifecycle of an SwiftUI app. By injecting an App-global `task(_:)` modifier, Spezi executes the `run()` method of all `ServiceModule`s. The tasks of all Modules are automatically cancelled once the app terminates.

## :gear: Release Notes
* Add new `ServiceModule` protocol to participate in structured concurrency.


## :books: Documentation
Highlighted the new protocol in the DocC target.


## :white_check_mark: Testing
Added a UI test to verify the behavior.

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
