### PR TITLE
try to fix a crash in the simulator

### DIFF
--- a/Sources/Spezi/Notifications/RemoteNotificationRegistrationSupport.swift
+++ b/Sources/Spezi/Notifications/RemoteNotificationRegistrationSupport.swift
@@ -58,7 +58,10 @@ public final class RemoteNotificationRegistrationSupport: KnowledgeSource, Senda
 #if targetEnvironment(simulator)
         async let _ = withTimeout(of: .seconds(5)) { @MainActor in
             logger.warning("Registering for remote notifications seems to be not possible on this simulator device. Timing out ...")
-            self.continuation?.resume(with: .failure(TimeoutError()))
+            if let continuation {
+                self.continuation = nil
+                continuation.resume(with: .failure(TimeoutError()))
+            }
         }
 #endif
 

--- a/Sources/Spezi/Notifications/RemoteNotificationRegistrationSupport.swift
+++ b/Sources/Spezi/Notifications/RemoteNotificationRegistrationSupport.swift
@@ -58,10 +58,7 @@ public final class RemoteNotificationRegistrationSupport: KnowledgeSource, Senda
 #if targetEnvironment(simulator)
         async let _ = withTimeout(of: .seconds(5)) { @MainActor in
             logger.warning("Registering for remote notifications seems to be not possible on this simulator device. Timing out ...")
-            if let continuation {
-                self.continuation = nil
-                continuation.resume(with: .failure(TimeoutError()))
-            }
+            resume(with: .failure(TimeoutError()))
         }
 #endif
 


### PR DESCRIPTION
# try to fix a crash in the simulator

## :recycle: Current situation & Problem
the continuation in the `RemoteNotificationRegistrationSupport` sometimes can get resumed twice, which obviously isn't allowed.
no regression test since i'm not sure how to reproduce this since i only encountered it once (after closing the lid on my macbook while i had a Spezi app running in the simulator); this PR is a best-effort attempt that'll likely fix the issue.

## :gear: Release Notes
- fixed a potential crash in the simulator

## :books: Documentation
n/a

## :white_check_mark: Testing
n/a

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
