### PR TITLE
make some things SPI

### DIFF
--- a/Sources/Spezi/Module/ModuleCollection.swift
+++ b/Sources/Spezi/Module/ModuleCollection.swift
@@ -12,9 +12,7 @@
 /// You can not create a ``ModuleCollection`` yourself. Please use the ``ModuleBuilder`` to create a ``ModuleCollection``.
 public class ModuleCollection {
     /// The elements of the collection.
-    @_spi(Spezi)
-    public let elements: [any Module]
-
+    package let elements: [any Module]
     
     init(elements: [any Module]) {
         self.elements = elements

--- a/Sources/Spezi/Module/ModuleCollection.swift
+++ b/Sources/Spezi/Module/ModuleCollection.swift
@@ -12,7 +12,9 @@
 /// You can not create a ``ModuleCollection`` yourself. Please use the ``ModuleBuilder`` to create a ``ModuleCollection``.
 public class ModuleCollection {
     /// The elements of the collection.
-    package let elements: [any Module]
+    @_spi(Spezi)
+    public let elements: [any Module]
+
     
     init(elements: [any Module]) {
         self.elements = elements

--- a/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
+++ b/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
@@ -10,17 +10,18 @@ import SpeziFoundation
 import SwiftUI
 
 
-package struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
-    package typealias Anchor = SpeziAnchor
+@_spi(Spezi)
+public struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
+    public typealias Anchor = SpeziAnchor
 
 #if os(iOS) || os(visionOS) || os(tvOS)
-    package typealias Value = [UIApplication.LaunchOptionsKey: Any]
+    public typealias Value = [UIApplication.LaunchOptionsKey: Any]
 #elseif os(macOS)
     /// Currently not supported as ``SpeziAppDelegate/applicationWillFinishLaunching(_:)`` on macOS
     /// is executed after the initialization of ``Spezi/Spezi`` via `View/spezi(_:)` is done, breaking our initialization assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
-    package typealias Value = [Never: Any]
+    public typealias Value = [Never: Any]
 #else // os(watchOS)
-    package typealias Value = [Never: Any]
+    public typealias Value = [Never: Any]
 #endif
 
     // Unsafe, non-isolated is fine as we have an empty dictionary.
@@ -28,7 +29,7 @@ package struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
     // Dealing with launch options in a safe way is up to the implementing Module to do so. Ideally we would make
     // `Application/launchOptions` to be isolated to the MainActor. However, we can't really do that selectively with the @Application
     // property wrapper. Most likely, you would interact with launch options in the `configure()` method which is @MainActor isolated.
-    package static nonisolated(unsafe) let defaultValue: Value = [:]
+    public static nonisolated(unsafe) let defaultValue: Value = [:]
 }
 
 

--- a/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
+++ b/Sources/Spezi/Spezi/KnowledgeSources/LaunchOptionsKey.swift
@@ -10,18 +10,17 @@ import SpeziFoundation
 import SwiftUI
 
 
-@_spi(Spezi)
-public struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
-    public typealias Anchor = SpeziAnchor
+package struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
+    package typealias Anchor = SpeziAnchor
 
 #if os(iOS) || os(visionOS) || os(tvOS)
-    public typealias Value = [UIApplication.LaunchOptionsKey: Any]
+    package typealias Value = [UIApplication.LaunchOptionsKey: Any]
 #elseif os(macOS)
     /// Currently not supported as ``SpeziAppDelegate/applicationWillFinishLaunching(_:)`` on macOS
     /// is executed after the initialization of ``Spezi/Spezi`` via `View/spezi(_:)` is done, breaking our initialization assumption in ``SpeziAppDelegate/applicationWillFinishLaunching(_:)``.
-    public typealias Value = [Never: Any]
+    package typealias Value = [Never: Any]
 #else // os(watchOS)
-    public typealias Value = [Never: Any]
+    package typealias Value = [Never: Any]
 #endif
 
     // Unsafe, non-isolated is fine as we have an empty dictionary.
@@ -29,7 +28,7 @@ public struct LaunchOptionsKey: DefaultProvidingKnowledgeSource {
     // Dealing with launch options in a safe way is up to the implementing Module to do so. Ideally we would make
     // `Application/launchOptions` to be isolated to the MainActor. However, we can't really do that selectively with the @Application
     // property wrapper. Most likely, you would interact with launch options in the `configure()` method which is @MainActor isolated.
-    public static nonisolated(unsafe) let defaultValue: Value = [:]
+    package static nonisolated(unsafe) let defaultValue: Value = [:]
 }
 
 

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -105,7 +105,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     /// Array of all SwiftUI `ViewModifiers` collected using `_ModifierPropertyWrapper` from the configured ``Module``s.
     ///
     /// Any changes to this property will cause a complete re-render of the SwiftUI view hierarchy. See `SpeziViewModifier`.
-    @MainActor package var viewModifiers: [any ViewModifier] {
+    @_spi(Spezi)
+    @MainActor public var viewModifiers: [any ViewModifier] {
         _viewModifiers
             // View modifiers of inner-most modules are added first due to the dependency order.
             // However, we want view modifiers of dependencies to be available for inside view modifiers of the parent
@@ -126,8 +127,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
              Otherwise use the SwiftUI onReceive(_:perform:) for UI related notifications.
              """
     )
-    
-    @MainActor package var lifecycleHandler: [any LifecycleHandler] {
+    @_spi(Spezi)
+    @MainActor public var lifecycleHandler: [any LifecycleHandler] {
         modules.compactMap { module in
             module as? any LifecycleHandler
         }
@@ -179,8 +180,9 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     ///   - standard: The standard to use.
     ///   - modules: The collection of modules to initialize.
     ///   - storage: Optional, initial storage to inject.
+    @_spi(Spezi)
     @MainActor
-    package init(
+    public init(
         standard: any Standard,
         modules: [any Module],
         storage: consuming SpeziStorage = SpeziStorage()

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -105,7 +105,7 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     /// Array of all SwiftUI `ViewModifiers` collected using `_ModifierPropertyWrapper` from the configured ``Module``s.
     ///
     /// Any changes to this property will cause a complete re-render of the SwiftUI view hierarchy. See `SpeziViewModifier`.
-    @MainActor package var viewModifiers: [any ViewModifier] {
+    @MainActor var viewModifiers: [any ViewModifier] {
         _viewModifiers
             // View modifiers of inner-most modules are added first due to the dependency order.
             // However, we want view modifiers of dependencies to be available for inside view modifiers of the parent

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -105,8 +105,7 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     /// Array of all SwiftUI `ViewModifiers` collected using `_ModifierPropertyWrapper` from the configured ``Module``s.
     ///
     /// Any changes to this property will cause a complete re-render of the SwiftUI view hierarchy. See `SpeziViewModifier`.
-    @_spi(Spezi)
-    @MainActor public var viewModifiers: [any ViewModifier] {
+    @MainActor package var viewModifiers: [any ViewModifier] {
         _viewModifiers
             // View modifiers of inner-most modules are added first due to the dependency order.
             // However, we want view modifiers of dependencies to be available for inside view modifiers of the parent
@@ -127,8 +126,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
              Otherwise use the SwiftUI onReceive(_:perform:) for UI related notifications.
              """
     )
-    @_spi(Spezi)
-    @MainActor public var lifecycleHandler: [any LifecycleHandler] {
+    
+    @MainActor package var lifecycleHandler: [any LifecycleHandler] {
         modules.compactMap { module in
             module as? any LifecycleHandler
         }
@@ -180,9 +179,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     ///   - standard: The standard to use.
     ///   - modules: The collection of modules to initialize.
     ///   - storage: Optional, initial storage to inject.
-    @_spi(Spezi)
     @MainActor
-    public init(
+    package init(
         standard: any Standard,
         modules: [any Module],
         storage: consuming SpeziStorage = SpeziStorage()

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -195,7 +195,9 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
             // load standard separately, such that all module loading takes precedence
             try self.loadModules([standard], ownership: .spezi)
         } catch {
-            preconditionFailure(error.description)
+            print("Error initializing Spezi: \(error.description)")
+            fflush(stdout)
+            preconditionFailure()
         }
     }
     

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -105,7 +105,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
     /// Array of all SwiftUI `ViewModifiers` collected using `_ModifierPropertyWrapper` from the configured ``Module``s.
     ///
     /// Any changes to this property will cause a complete re-render of the SwiftUI view hierarchy. See `SpeziViewModifier`.
-    @MainActor var viewModifiers: [any ViewModifier] {
+    @_spi(Spezi)
+    @MainActor public var viewModifiers: [any ViewModifier] {
         _viewModifiers
             // View modifiers of inner-most modules are added first due to the dependency order.
             // However, we want view modifiers of dependencies to be available for inside view modifiers of the parent

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -195,9 +195,7 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
             // load standard separately, such that all module loading takes precedence
             try self.loadModules([standard], ownership: .spezi)
         } catch {
-            print("Error initializing Spezi: \(error.description)")
-            fflush(stdout)
-            preconditionFailure()
+            preconditionFailure(error.description)
         }
     }
     

--- a/Sources/Spezi/Spezi/Spezi.swift
+++ b/Sources/Spezi/Spezi/Spezi.swift
@@ -146,7 +146,8 @@ public final class Spezi: Sendable { // swiftlint:disable:this type_body_length
         }
     }
     
-    @MainActor var modules: [any Module] {
+    @_spi(APISupport)
+    @MainActor public var modules: [any Module] {
         storage.collect(allOf: (any AnyStoredModules).self)
             .reduce(into: []) { partialResult, modules in
                 partialResult.append(contentsOf: modules.anyModules)

--- a/Sources/Spezi/Spezi/SpeziAppDelegate.swift
+++ b/Sources/Spezi/Spezi/SpeziAppDelegate.swift
@@ -122,6 +122,7 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate, Sendable {
         var storage = SpeziStorage()
         storage[LaunchOptionsKey.self] = launchOptions
         self._spezi = Spezi(from: configuration, storage: storage)
+        Self.appDelegate = self
 
         // backwards compatibility
         spezi.lifecycleHandler.willFinishLaunchingWithOptions(application, launchOptions: launchOptions ?? [:])
@@ -227,7 +228,6 @@ open class SpeziAppDelegate: NSObject, ApplicationDelegate, Sendable {
         options: UIScene.ConnectionOptions
     ) -> UISceneConfiguration {
         let sceneConfig = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
-        Self.appDelegate = self
         sceneConfig.delegateClass = SpeziSceneDelegate.self
         return sceneConfig
     }

--- a/Sources/Spezi/Spezi/View+Spezi.swift
+++ b/Sources/Spezi/Spezi/View+Spezi.swift
@@ -10,16 +10,17 @@ import Foundation
 import SwiftUI
 
 
-struct SpeziViewModifier: ViewModifier {
+@_spi(APISupport)
+public struct SpeziViewModifier: ViewModifier {
     @State private var spezi: Spezi
     
     
-    init(_ spezi: Spezi) {
+    public init(_ spezi: Spezi) {
         self.spezi = spezi
     }
     
     
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         spezi.viewModifiers
             .modify(content)
             .task(spezi.run) // service lifecycle

--- a/Sources/Spezi/Standard/DefaultStandard.swift
+++ b/Sources/Spezi/Standard/DefaultStandard.swift
@@ -7,7 +7,6 @@
 //
 
 
-@_spi(Spezi)
-public actor DefaultStandard: Standard {
-    public init() {}
+package actor DefaultStandard: Standard {
+    package init() {}
 }

--- a/Sources/Spezi/Standard/DefaultStandard.swift
+++ b/Sources/Spezi/Standard/DefaultStandard.swift
@@ -7,6 +7,7 @@
 //
 
 
-package actor DefaultStandard: Standard {
-    package init() {}
+@_spi(Spezi)
+public actor DefaultStandard: Standard {
+    public init() {}
 }

--- a/Sources/SpeziTesting/DependencyResolution.swift
+++ b/Sources/SpeziTesting/DependencyResolution.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-import Spezi
+@_spi(Spezi) import Spezi
 import SwiftUI
 
 

--- a/Sources/SpeziTesting/DependencyResolution.swift
+++ b/Sources/SpeziTesting/DependencyResolution.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(Spezi) import Spezi
+import Spezi
 import SwiftUI
 
 

--- a/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(Spezi) @testable import Spezi
+@testable import Spezi
 import SwiftUI
 import Testing
 

--- a/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
+++ b/Tests/SpeziTests/CapabilityTests/ViewModifierTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import Spezi
+@_spi(Spezi) @testable import Spezi
 import SwiftUI
 import Testing
 

--- a/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(Spezi) @_spi(APISupport) @testable import Spezi
+@_spi(APISupport) @testable import Spezi
 import SwiftUI
 import XCTest
 import XCTRuntimeAssertions

--- a/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
+++ b/Tests/SpeziTests/DependenciesTests/DependencyTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(APISupport) @testable import Spezi
+@_spi(Spezi) @_spi(APISupport) @testable import Spezi
 import SwiftUI
 import XCTest
 import XCTRuntimeAssertions

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable @_spi(Spezi) import Spezi
+@testable import Spezi
 import XCTest
 
 

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@testable import Spezi
+@testable @_spi(Spezi) import Spezi
 import XCTest
 
 

--- a/Tests/SpeziTests/ModuleTests/ModuleTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(Spezi) @_spi(APISupport) @testable import Spezi
+@_spi(APISupport) @testable import Spezi
 import SpeziTesting
 import SwiftUI
 import Testing

--- a/Tests/SpeziTests/ModuleTests/ModuleTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(Spezi) @testable import Spezi
+@_spi(Spezi) @_spi(APISupport) @testable import Spezi
 import SpeziTesting
 import SwiftUI
 import Testing

--- a/Tests/SpeziTests/ModuleTests/ModuleTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleTests.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-@_spi(APISupport) @testable import Spezi
+@_spi(Spezi) @_spi(APISupport) @testable import Spezi
 import SpeziTesting
 import SwiftUI
 import Testing


### PR DESCRIPTION
# make some things SPI

## :recycle: Current situation & Problem
this PR makes a couple of APIs SPI, enabling their use in external packages and apps. the motivation here is the SpeziOneSec integration, where we need to bootstrap and inject Spezi w/out being able to directly access the SwiftUI view hierarchy (ie, can't use the `spezi(_:)` modifier).

## :gear: Release Notes
n/a


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
