### PR TITLE
Enable Module Nesting for `@ModuleBuilder`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug]
+        config: [Debug, Release]
         platform:
           - name: iOS
             destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
@@ -50,7 +50,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug]
+        config: [Debug, Release]
         platform:
           - name: iOS
             destination: 'platform=iOS Simulator,name=iPhone 17 Pro'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,75 +15,59 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: Build-and-Test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  buildandtest_ios:
-    name: Build and Test Swift Package iOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+  package_tests:
+    name: Build and Test Swift Package ${{ matrix.platform.name }} (${{ matrix.config }})
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    strategy:
+      matrix:
+        config: [Debug]
+        platform:
+          - name: iOS
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
+          - name: macOS
+            destination: 'platform=macOS,arch=arm64'
+          - name: watchOS
+            destination: 'platform=watchOS Simulator,name=Apple Watch Series 11 (46mm)'
+          - name: visionOS
+            destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
+          - name: tvOS
+            destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'
+      fail-fast: false
     with:
       runsonlabels: '["macOS", "self-hosted"]'
       scheme: Spezi-Package
-      resultBundle: Spezi-Package-iOS.xcresult
-      artifactname: Spezi-Package-iOS.xcresult
-  buildandtest_watchos:
-    name: Build and Test Swift Package watchOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+      destination: ${{ matrix.platform.destination }}
+      buildConfig: ${{ matrix.config }}
+      resultBundle: ${{ format('Spezi-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
+      artifactname: ${{ format('Spezi-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
+  ui_tests:
+    name: Build and Test UI Tests ${{ matrix.platform.name }} (${{ matrix.config }})
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    strategy:
+      matrix:
+        config: [Debug]
+        platform:
+          - name: iOS
+            destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
+          - name: visionOS
+            destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
     with:
       runsonlabels: '["macOS", "self-hosted"]'
-      scheme: Spezi-Package
-      destination: 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
-      resultBundle: Spezi-Package-watchOS.xcresult
-      artifactname: Spezi-Package-watchOS.xcresult
-  buildandtest_visionos:
-    name: Build and Test Swift Package visionOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: Spezi-Package
-      destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
-      resultBundle: Spezi-Package-visionOS.xcresult
-      artifactname: Spezi-Package-visionOS.xcresult
-  buildandtest_tvos:
-    name: Build and Test Swift Package tvOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: Spezi-Package
-      destination: 'platform=tvOS Simulator,name=Apple TV 4K (3rd generation)'
-      resultBundle: Spezi-Package-tvOS.xcresult
-      artifactname: Spezi-Package-tvOS.xcresult
-  buildandtest_macos:
-    name: Build and Test Swift Package macOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      scheme: Spezi-Package
-      destination: 'platform=macOS,arch=arm64'
-      resultBundle: Spezi-Package-macOS.xcresult
-      artifactname: Spezi-Package-macOS.xcresult
-  buildandtestuitests_ios:
-    name: Build and Test UI Tests iOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      path: Tests/UITests
+      path: 'Tests/UITests'
       scheme: TestApp
-      resultBundle: TestApp-iOS.xcresult
-      artifactname: TestApp-iOS.xcresult
-  buildandtestuitests_visionos:
-    name: Build and Test UI Tests visionOS
-    uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    with:
-      runsonlabels: '["macOS", "self-hosted"]'
-      path: Tests/UITests
-      scheme: TestApp
-      destination: 'platform=visionOS Simulator,name=Apple Vision Pro'
-      resultBundle: TestApp-visionOS.xcresult
-      artifactname: TestApp-visionOS.xcresult
+      destination: ${{ matrix.platform.destination }}
+      resultBundle: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
+      artifactname: ${{ format('TestApp-{0}-{1}.xcresult', matrix.platform.name, matrix.config) }}
   uploadcoveragereport:
     name: Upload Coverage Report
-    needs: [buildandtest_ios, buildandtest_watchos, buildandtest_visionos, buildandtest_tvos, buildandtest_macos, buildandtestuitests_ios, buildandtestuitests_visionos]
-    uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
+    needs: [package_tests, ui_tests]
+    uses: StanfordBDHG/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
-      coveragereports: Spezi-Package-iOS.xcresult Spezi-Package-watchOS.xcresult Spezi-Package-visionOS.xcresult Spezi-Package-tvOS.xcresult Spezi-Package-macOS.xcresult TestApp-iOS.xcresult TestApp-visionOS.xcresult
+      coveragereports: Spezi-*.xcresult TestApp-*.xcresult
     secrets:
       token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug, Release]
+        config: [Debug]
         platform:
           - name: iOS
             destination: 'platform=iOS Simulator,name=iPhone 17 Pro'
@@ -50,7 +50,7 @@ jobs:
     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     strategy:
       matrix:
-        config: [Debug, Release]
+        config: [Debug]
         platform:
           - name: iOS
             destination: 'platform=iOS Simulator,name=iPhone 17 Pro'

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,16 +1,23 @@
 #
 # This source file is part of the Stanford Spezi open-source project
 #
-# SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+# SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
 #
 # SPDX-License-Identifier: MIT
 #
 
-name: Pull Request
+name: Static Analysis
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: Static-Analysis-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   reuse_action:
@@ -25,5 +32,6 @@ jobs:
   breaking_changes:
     name: Diagnose Breaking Changes
     uses: StanfordSpezi/.github/.github/workflows/breaking-changes.yml@v2
+    if: ${{ github.ref_name != 'main' }}
     with:
       runsonlabels: '["macOS", "self-hosted"]'

--- a/Sources/Spezi/Module/ModuleBuilder.swift
+++ b/Sources/Spezi/Module/ModuleBuilder.swift
@@ -15,6 +15,11 @@ public enum ModuleBuilder {
         [expression]
     }
     
+    /// If declared, provides contextual type information for statement expressions to translate them into partial results.
+    public static func buildExpression(_ expression: ModuleCollection) -> [any Module] {
+        expression.elements
+    }
+    
     /// Required by every result builder to build combined results from statement blocks.
     public static func buildBlock(_ modules: [any Module]...) -> [any Module] {
         modules.flatMap { $0 }

--- a/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
+++ b/Tests/SpeziTests/ModuleTests/ModuleBuilderTests.swift
@@ -14,6 +14,8 @@ final class ModuleBuilderTests: XCTestCase {
     private struct Expectations {
         weak var xctestCase: XCTestCase?
         var firstTestExpectation = Expectations.expectation(named: "FirstTestModule")
+        var nestedTestModuleOne = Expectations.expectation(named: "NestedTestModuleOne")
+        var nestedTestModuleTwo = Expectations.expectation(named: "NestedTestModuleTwo")
         var loopTestExpectation = Expectations.expectation(named: "LoopTestModule")
         var conditionalTestExpectation = Expectations.expectation(named: "ConditionalTestModule")
         var availableConditionalTestExpectation = Expectations.expectation(named: "AvailableConditionalTestExpection")
@@ -41,6 +43,8 @@ final class ModuleBuilderTests: XCTestCase {
             xctestCase.wait(
                 for: [
                     firstTestExpectation,
+                    nestedTestModuleOne,
+                    nestedTestModuleTwo,
                     loopTestExpectation,
                     conditionalTestExpectation,
                     availableConditionalTestExpectation,
@@ -55,8 +59,15 @@ final class ModuleBuilderTests: XCTestCase {
     
     private func modules(loopLimit: Int, condition: Bool, expectations: Expectations) -> ModuleCollection {
         @ModuleBuilder
+        var nestedModules: ModuleCollection {
+            TestModule(expectation: expectations.nestedTestModuleOne)
+            TestModule(expectation: expectations.nestedTestModuleTwo)
+        }
+        
+        @ModuleBuilder
         var modules: ModuleCollection {
             TestModule(expectation: expectations.firstTestExpectation)
+            nestedModules
             for _ in 0..<loopLimit {
                 TestModule(expectation: expectations.loopTestExpectation)
             }

--- a/Tests/SpeziTests/Shared/TestApplicationDelegate.swift
+++ b/Tests/SpeziTests/Shared/TestApplicationDelegate.swift
@@ -12,25 +12,25 @@ import Testing
 import XCTest
 
 
-public class TestApplicationDelegate: SpeziAppDelegate {
+class TestApplicationDelegate: SpeziAppDelegate {
     let confirmation: Confirmation?
     let expectation: XCTestExpectation
     
     
-    override public var configuration: Configuration {
+    override var configuration: Configuration {
         Configuration {
             TestModule(confirmation: confirmation, expectation: expectation)
         }
     }
 
 
-    public init(expectation: XCTestExpectation) {
+    init(expectation: XCTestExpectation) {
         self.confirmation = nil
         self.expectation = expectation
         super.init()
     }
 
-    public init(confirmation: Confirmation) {
+    init(confirmation: Confirmation) {
         self.confirmation = confirmation
         self.expectation = .init()
         super.init()

--- a/Tests/SpeziTests/Shared/TestApplicationDelegate.swift
+++ b/Tests/SpeziTests/Shared/TestApplicationDelegate.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-#if DEBUG
 import Spezi
 import SwiftUI
 import Testing
@@ -37,4 +36,3 @@ public class TestApplicationDelegate: SpeziAppDelegate {
         super.init()
     }
 }
-#endif

--- a/Tests/SpeziTests/Shared/TestModule.swift
+++ b/Tests/SpeziTests/Shared/TestModule.swift
@@ -21,7 +21,7 @@ struct TestViewModifier: ViewModifier {
 }
 
 
-public final class TestModule: Module {
+final class TestModule: Module {
     let confirmation: Confirmation?
     let expectation: XCTestExpectation
 
@@ -29,13 +29,13 @@ public final class TestModule: Module {
     @Modifier var modifier2 = TestViewModifier(message: "World")
 
     
-    public init(confirmation: Confirmation? = nil, expectation: XCTestExpectation = XCTestExpectation()) {
+    init(confirmation: Confirmation? = nil, expectation: XCTestExpectation = XCTestExpectation()) {
         self.confirmation = confirmation
         self.expectation = expectation
     }
     
     
-    public func configure() {
+    func configure() {
         expectation.fulfill()
         confirmation?()
     }

--- a/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
+++ b/Tests/UITests/TestApp/RemoteNotifications/RemoteNotificationsTestView.swift
@@ -67,9 +67,7 @@ struct RemoteNotificationsTestView: View {
 }
 
 
-#if DEBUG
 #Preview {
     RemoteNotificationsTestView()
         .environment(NotificationModule())
 }
-#endif

--- a/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
+++ b/Tests/UITests/TestAppUITests/LifecycleHandlerTests.swift
@@ -63,7 +63,7 @@ final class LifecycleHandlerTests: XCTestCase {
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
 
-        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
 
         let springboard = XCUIApplication(bundleIdentifier: XCUIApplication.homeScreenBundle)
 #if os(visionOS)
@@ -77,7 +77,7 @@ final class LifecycleHandlerTests: XCTestCase {
         app.activate()
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
 
 #if os(visionOS)
         springboard.launch() // springboard is in `runningBackgroundSuspended` state on visionOS. So we need to launch it not just activate
@@ -89,6 +89,6 @@ final class LifecycleHandlerTests: XCTestCase {
         app.launch()
 
         XCTAssertTrue(app.wait(for: .runningForeground, timeout: 2.0))
-        XCTAssertTrue(app.staticTexts["Module is running."].exists)
+        XCTAssertTrue(app.staticTexts["Module is running."].waitForExistence(timeout: 2.0))
     }
 }


### PR DESCRIPTION
# Enable Module Nesting for `@ModuleBuilder`

## :recycle: Current situation & Problem
- It is not possible to provide a nested mechanism for the `@ModuleBuilder` to e.g. create a shared set of modules for the `.previewWith(...)` modifier.

## :gear: Release Notes
- Enables module nesting for `@ModuleBuilder`

## :books: Documentation
- Documentation still up to date

## :white_check_mark: Testing
- Add relevant tests


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
